### PR TITLE
set default region for aws cli to project's region

### DIFF
--- a/pkg/project/stack.go
+++ b/pkg/project/stack.go
@@ -36,6 +36,7 @@ func (s *stack) runtime() (string, error) {
 			"AWS_ACCESS_KEY_ID":     credentials.AccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": credentials.SecretAccessKey,
 			"AWS_SESSION_TOKEN":     credentials.SessionToken,
+			"AWS_DEFAULT_REGION":    s.project.Region(),
 		},
 		"bootstrap": map[string]string{
 			"bucket": bootstrap,


### PR DESCRIPTION
So when the project's region is different from the default region set in `~/.aws/config` the cli doesn't work so we can override the default region by setting the `AWS_DEFAULT_REGION` to project's region