### PR TITLE
Replaced Vercel with SST as host in NextJS example's README

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -29,8 +29,9 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deploy with SST
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Deploy NextJS on AWS with [SST](https://sst.dev) and [Open-Next](https://open-next.js.org/) (It's free NextJS!)
+Open-Next is much easier to integrate with an existing AWS back-end, and is a lot cheaper than Vercel.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Check out our [SST with Next.js deployment documentation](https://docs.sst.dev/start/nextjs) for more details.


### PR DESCRIPTION
Extremely vital update to make sure you guys don't give your competition free PR.

On a serious note, if you guys got any chores or tasks you would like to have done I would love to contribute!