### PR TITLE
Update curl URL

### DIFF
--- a/www/src/content/docs/docs/reference/cli.mdx
+++ b/www/src/content/docs/docs/reference/cli.mdx
@@ -15,7 +15,7 @@ import InlineSection from '../../../../../src/components/tsdoc/InlineSection.ast
 The CLI helps you manage your SST apps.
 
 ```bash title="Install"
-curl -fsSL https://ion.sst.dev/install.sh | bash
+curl -fsSL https://ion.sst.dev/install | bash
 ```
 
 :::note
@@ -190,8 +190,6 @@ The value of the secret.
 </Section>
 
 Set the value of the secret.
-
-The secrets are encrypted and stored in an S3 Bucket in your AWS account.
 
 For example, set the `sst.Secret` called `StripeSecret` to `123456789`.
 


### PR DESCRIPTION
https://ion.sst.dev/install.sh returns a 403, removing the '.sh' resolves the issue