### PR TITLE
fix: Make sure sst_links are set for cjs bundled functions

### DIFF
--- a/pkg/platform/src/runtime/node.ts
+++ b/pkg/platform/src/runtime/node.ts
@@ -91,14 +91,12 @@ export async function build(
       : {
           format: "cjs",
           target: "node14",
-          banner: nodejs.banner
-            ? {
-                js: [
-                  `globalThis.$SST_LINKS = ${JSON.stringify(links)};`,
-                  nodejs.banner || "",
-                ].join("\n"),
-              }
-            : undefined,
+          banner: {
+            js: [
+              `globalThis.$SST_LINKS = ${JSON.stringify(links)};`,
+              nodejs.banner || "",
+            ].join("\n"),
+          },
         }),
     outfile: !nodejs.splitting ? target : undefined,
     outdir: nodejs.splitting ? path.dirname(target) : undefined,


### PR DESCRIPTION
- GlobalThis wasn't being set with the links if you didn't pass a banner (which I wasn't)
- Just copy the same logic as esm just above