### PR TITLE
fix: Grant more explicit permissions for postgres link

### DIFF
--- a/pkg/platform/src/components/aws/postgres.ts
+++ b/pkg/platform/src/components/aws/postgres.ts
@@ -278,7 +278,13 @@ export class Postgres
         resources: [this.cluster.masterUserSecrets[0].secretArn],
       },
       {
-        actions: ["rds-data:ExecuteStatement"],
+        actions: [
+          "rds-data:BatchExecuteStatement",
+          "rds-data:BeginTransaction",
+          "rds-data:CommitTransaction",
+          "rds-data:ExecuteStatement",
+          "rds-data:RollbackTransaction",
+        ],
         resources: [this.cluster.arn],
       },
     ];


### PR DESCRIPTION
- A common use case is using drizzle or similar orms which require more than just execute statement. I opted not to use `rds-data:*` just incase if they are actions added later we will explicitly add them.