### PR TITLE
S3 website endpoints only support HTTP

### DIFF
--- a/pkg/platform/src/components/aws/https-redirect.ts
+++ b/pkg/platform/src/components/aws/https-redirect.ts
@@ -115,7 +115,7 @@ export class HttpsRedirect extends Component {
             customOriginConfig: {
               httpPort: 80,
               httpsPort: 443,
-              originProtocolPolicy: "https-only",
+              originProtocolPolicy: "http-only",
               originSslProtocols: ["TLSv1.2"],
             },
           },


### PR DESCRIPTION
[following the example in the docs](https://ion.sst.dev/docs/component/aws/nextjs/#domain-redirects) to redirect www -> apex, I saw a 504 when browsing www subdomain. After making this change, the redirect worked successfully. s3 websites only support http.

[discord thread](https://discord.com/channels/983865673656705025/1218574183550681209/1218574183550681209)