### PR TITLE
fixes incorrect AWS documentation url in apigatewayv2.ts

### DIFF
--- a/pkg/platform/src/components/aws/apigatewayv2.ts
+++ b/pkg/platform/src/components/aws/apigatewayv2.ts
@@ -252,7 +252,7 @@ export interface ApiGatewayV2RouteArgs {
 }
 
 /**
- * The `ApiGatewayV2` component lets you add an [Amazon API Gateway HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.htmll) to your app.
+ * The `ApiGatewayV2` component lets you add an [Amazon API Gateway HTTP API](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) to your app.
  *
  * @example
  *


### PR DESCRIPTION
fixes incorrect documentation url from ``https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.htmll`` to ``https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html``