### PR TITLE
Fix a typo in sns docs

### DIFF
--- a/examples/solid-hacker-news/app.config.ts
+++ b/examples/solid-hacker-news/app.config.ts
@@ -1,3 +1,7 @@
 import { defineConfig } from "@solidjs/start/config";
 
-export default defineConfig({});
+export default defineConfig({
+  server: {
+    preset: "aws-lambda",
+  },
+});

--- a/examples/solid-hacker-news/sst.config.ts
+++ b/examples/solid-hacker-news/sst.config.ts
@@ -1,11 +1,11 @@
 /// <reference path="./.sst/platform/config.d.ts" />
-
 export default $config({
   app(input) {
     return {
       name: "solid-hacker-news",
       removal: input?.stage === "production" ? "retain" : "remove",
       home: "aws",
+      providers: { "@runpod-infra/pulumi": true },
     };
   },
   async run() {

--- a/pkg/platform/src/components/aws/apigatewayv2.ts
+++ b/pkg/platform/src/components/aws/apigatewayv2.ts
@@ -14,7 +14,6 @@ import { hashStringToPrettyString, sanitizeToPascalCase } from "../naming";
 import { VisibleError } from "../error";
 import { HostedZoneLookup } from "./providers/hosted-zone-lookup";
 import { DnsValidatedCertificate } from "./dns-validated-certificate";
-import { useProvider } from "./helpers/provider";
 import { Hint } from "../hint";
 
 interface DomainArgs {

--- a/pkg/platform/src/components/aws/solid-start.ts
+++ b/pkg/platform/src/components/aws/solid-start.ts
@@ -389,6 +389,12 @@ export class SolidStart extends Component implements Link.Linkable {
                   cfFunction: "serverCfFunction",
                   origin: "server",
                 },
+            {
+              pattern: "_server/",
+              cacheType: "server",
+              cfFunction: "serverCfFunction",
+              origin: "server",
+            },
             // create 1 behaviour for each top level asset file/folder
             ...fs.readdirSync(path.join(outputPath, ".output/public")).map(
               (item) =>

--- a/pkg/project/install.go
+++ b/pkg/project/install.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -153,9 +154,9 @@ func (p *Project) fetchDeps() error {
 	cmd := exec.Command("bun", "install")
 	cmd.Dir = p.PathPlatformDir()
 
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return errors.New("failed to run bun install " + string(output))
 	}
 	return nil
 }

--- a/www/src/content/docs/docs/component/aws/sns-topic.mdx
+++ b/www/src/content/docs/docs/component/aws/sns-topic.mdx
@@ -55,7 +55,7 @@ Once linked, you can publish messages to the topic from your function code.
 
 ```ts title="app/page.tsx" {1,7}
 import { Resource } from "sst";
-import { SNSClient, PublishCommand } from "@aws-sdk/client-sqs";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 
 const sns = new SNSClient({});
 


### PR DESCRIPTION
Hey I believe there's a typo in sns docs since the SNSClient should be imported from `@aws-sdk/client-sns` and rather than `@aws-sdk/client-sqs`. 