### PR TITLE
Follow XDG base dir spec in install script

### DIFF
--- a/install
+++ b/install
@@ -35,7 +35,7 @@ case "$filename" in
     ;;
 esac
 
-INSTALL_DIR=$HOME/.sst/bin
+INSTALL_DIR=${XDG_BIN_HOME:-$HOME/.local/bin}
 mkdir -p "$INSTALL_DIR"
 
 if [ -z "$requested_version" ]; then


### PR DESCRIPTION
sst/sst#4666 

---

- [x] **Implement:** modify install script to use `$XDG_BIN_HOME` as install dir and default to `$HOME/.local/bin` if `$XDG_BIN_HOME` doesn't exist
- [x] **Implement:** modify `sst upgrade` command to use the same logic for determining the install dir
- [x] **Test:** run install script with
  - [x] $XDG_BIN_HOME set and already in $PATH
  - [x] $XDG_BIN_HOME set and not in $PATH
  - [x] $XDG_BIN_HOME not set
- [x] **Test:** verify `sst upgrade` works as expected
  - [x] build `sst` executable and manually install
  - [x] run `sst upgrade` and verify it uses the $XDG_BIN_HOME dir
