### PR TITLE
fix upgrade command version comparison

### DIFF
--- a/pkg/global/upgrade.go
+++ b/pkg/global/upgrade.go
@@ -54,13 +54,7 @@ func Upgrade(existingVersion string, nextVersion string) (string, error) {
 		}
 		nextVersion = releaseInfo.TagName
 	}
-	if !strings.HasPrefix(nextVersion, "v") {
-		nextVersion = "v" + nextVersion
-	}
-	if !strings.HasPrefix(existingVersion, "v") {
-		existingVersion = "v" + existingVersion
-	}
-	if nextVersion == existingVersion {
+	if strings.TrimLeft(nextVersion, "v") == strings.TrimLeft(existingVersion, "v") {
 		return nextVersion, nil
 	}
 	url := "https://github.com/sst/ion/releases/download/" + nextVersion + "/sst-" + filename


### PR DESCRIPTION
fixes
```
❯ sst upgrade --verbose
time=2024-03-27T15:50:33.478-04:00 level=INFO msg="checking for bun" path=".../sst/bin/bun"
time=2024-03-27T15:50:33.536-04:00 level=INFO msg=downloading url=https://github.com/sst/ion/releases/download/v0.0.215/sst-mac-arm64.tar.gz
time=2024-03-27T15:50:33.595-04:00 level=ERROR msg="exited with error" err="unexpected HTTP status when downloading release: 404 Not Found"
×  Unexpected error occurred. Please check the logs or run with --verbose for more details.
```
where `https://github.com/sst/ion/releases/download/v0.0.215/sst-mac-arm64.tar.gz` should be `https://github.com/sst/ion/releases/download/0.0.215/sst-mac-arm64.tar.gz`