### PR TITLE
providers always loaded even when not set as home

### DIFF
--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	flag "github.com/spf13/pflag"
 	"io"
 	"log/slog"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
@@ -1474,6 +1475,10 @@ func initProject(cli *Cli) (*project.Project, error) {
 		if err != nil {
 			return nil, util.NewReadableError(err, "Could not install dependencies")
 		}
+	}
+
+	if err := p.LoadProviders(); err != nil {
+		return nil, util.NewReadableError(err, err.Error())
 	}
 
 	if err := p.LoadHome(); err != nil {

--- a/pkg/project/provider/generic.go
+++ b/pkg/project/provider/generic.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/sst/ion/internal/util"
+)
+
+type GenericProvider struct {
+	key  string
+	args map[string]interface{}
+	env  map[string]string
+}
+
+func (p *GenericProvider) Init(key string, args map[string]interface{}) (err error) {
+	p.key = key
+	p.args = args
+	p.env = map[string]string{}
+	return nil
+}
+
+func (p *GenericProvider) Key() string {
+	return p.key
+}
+
+func (p *GenericProvider) Env() (map[string]string, error) {
+	return nil, nil
+}
+
+func (p *GenericProvider) AsHome(app, stage string) (Home, error) {
+	return nil, util.NewReadableError(nil, fmt.Sprintf("\"%s\" is not a valid \"home\"", p.key))
+}

--- a/pkg/project/stack.go
+++ b/pkg/project/stack.go
@@ -134,10 +134,7 @@ func (s *stack) Run(ctx context.Context, input *StackInput) error {
 		return fmt.Errorf("failed to list secrets: %w", err)
 	}
 
-	env, err := s.project.home.Env()
-	if err != nil {
-		return err
-	}
+	env := s.project.Env()
 	for _, value := range os.Environ() {
 		pair := strings.SplitN(value, "=", 2)
 		if len(pair) == 2 {
@@ -482,10 +479,7 @@ func (s *stack) Import(ctx context.Context, input *ImportOptions) error {
 	if err != nil {
 		return err
 	}
-	env, err := s.project.home.Env()
-	if err != nil {
-		return err
-	}
+	env := s.project.Env()
 	env["PULUMI_CONFIG_PASSPHRASE"] = passphrase
 
 	ws, err := auto.NewLocalWorkspace(ctx,


### PR DESCRIPTION
My attempt to fix the issue I was having in sst/sst#4874. Literally the first go I've written so probably rough & broken 😅

What I'm trying to change is that currently only the "home" provider gets initialized:

https://github.com/sst/ion/blob/917a55c84931b88e076204f2424dbfe4e0128db1/pkg/project/project.go#L202-L212

And only "home" provider environment variables are passed to pulumi:

https://github.com/sst/ion/blob/917a55c84931b88e076204f2424dbfe4e0128db1/pkg/project/stack.go#L137

https://github.com/sst/ion/blob/917a55c84931b88e076204f2424dbfe4e0128db1/pkg/project/stack.go#L485

At which point (in my case) the cloudflare workerscript gets all mad that "accountId" or whatever is unset:

https://www.pulumi.com/registry/packages/cloudflare/api-docs/workerscript/

My idea here is to:
1. `Init()` every provider
2. Provide envvars from all providers (not just home)

I'm not sure if this fits the underlying pulumi model well, an alternative could be to just expose a global "env" config where I could set cloudflare bits etc. Or I'm dumb and it's not an issue in the first place