### PR TITLE
fix: Handle linux distros that report arm64 architecture as aarch64

### DIFF
--- a/install
+++ b/install
@@ -14,6 +14,10 @@ if [[ "$os" == "darwin" ]]; then
 fi
 arch=$(uname -m)
 
+if [[ "$arch" == "aarch64" ]]; then 
+  arch="arm64"
+fi
+
 filename="$APP-$os-$arch.tar.gz"
 
 case "$filename" in


### PR DESCRIPTION
Currently the install script fails silently on Linux distros that report arm64 architecture as "aarch64". This fixes the issue.