### PR TITLE
fix: install script exiting when global node install is present

### DIFF
--- a/install
+++ b/install
@@ -60,7 +60,7 @@ check_version() {
         sst_shebang=$(cat $sst_path | head -n1)
 
         if [[ "$sst_shebang" == "#!/usr/bin/env node" ]]; then
-            print_message error "sst is installed globally with NPM. Please uninstall before proceeding."
+            print_message error "SST v2 is installed globally through npm. You'll need to uninstall it before proceeding."
             exit 1
         fi
 

--- a/install
+++ b/install
@@ -44,23 +44,31 @@ print_message() {
     local level=$1
     local message=$2
     local color=""
-    
+
     case $level in
         info) color="${GREEN}" ;;
         warning) color="${YELLOW}" ;;
         error) color="${RED}" ;;
     esac
-    
+
     echo -e "${color}${message}${NC}"
 }
 
 check_version() {
     if command -v sst >/dev/null 2>&1; then
+        sst_path=$(which sst)
+        sst_shebang=$(cat $sst_path | head -n1)
+
+        if [[ "$sst_shebang" == "#!/usr/bin/env node" ]]; then
+            print_message error "sst is installed globally with NPM. Please uninstall before proceeding."
+            exit 1
+        fi
+
         installed_version=$(sst version)
-        
+
         if [[ "$installed_version" != "$latest_version" ]]; then
             print_message info "Installed version: ${YELLOW}$installed_version."
-            
+
             # print_message info "Version ${YELLOW}$installed_version${GREEN} is installed, upgrading to ${YELLOW}$latest_version${GREEN}? [Y/n]${NC}"
             # read -n 1 -r
             # echo


### PR DESCRIPTION
When a user has already installed SST globally via NPM, the install script exits with code 1 silently. 

## Steps to reproduce

1. Install SST via NPM

```bash
npm i -g sst@2
```

2. Attempt to install Ion

```bash
curl -fsSL https://ion.sst.dev/install | bash
```

3. See silent fail

## Cause

This is because the script detects the presence of `sst` in the path, but then attempts to grab the current version by running:

```bash
installed_version=$(sst version)
```

[^ Line 67](https://github.com/sst/ion/pull/176/files#diff-1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463R67)

That command will exit 1, with the following error:

```
Error: Could not find a configuration file
Make sure one of the following exists
  - sst.config.ts
  - sst.config.mts
  - sst.config.cts
  - sst.config.cjs
  - sst.config.mjs
  - sst.config.js

Need help with this error? Post it in #help on the SST Discord https://sst.dev/discord
```

The SST Ion install script will then exit silently 🙂

## Proposed fix

I've added a check to check the `sst` executable for a Node shebang. Hopefully this should be enough to understand whether it's an installation of v1/v2, and warn the user to uninstall first!

Please feel free to change the warning message to your preference.

Thanks! 

(ps. apologies for stray whitespace removal)

Fixes sst/sst#4813