### PR TITLE
fix: callback url replace regex

### DIFF
--- a/sdk/js/src/auth/adapter/oauth.ts
+++ b/sdk/js/src/auth/adapter/oauth.ts
@@ -37,7 +37,7 @@ export const OauthAdapter =
   (config: OauthConfig) => {
     return async function (routes, ctx) {
       function getClient(c: Context) {
-        const callback = c.req.url.replace(/authorize$/, "callback");
+        const callback = c.req.url.replace(/authorize\/.*$/, "callback");
         return [
           callback,
           new config.issuer.Client({

--- a/sdk/js/src/auth/adapter/oidc.ts
+++ b/sdk/js/src/auth/adapter/oidc.ts
@@ -21,7 +21,7 @@ export interface OidcConfig extends OidcBasicConfig {
 export const OidcAdapter = /* @__PURE__ */ (config: OidcConfig) => {
   return async function (routes, ctx) {
     routes.get("/authorize", async (c) => {
-      const callback = c.req.url.replace(/authorize$/, "callback");
+      const callback = c.req.url.replace(/authorize\/.*$/, "callback");
       const client = new config.issuer.Client({
         client_id: config.clientID,
         redirect_uris: [callback],
@@ -42,7 +42,7 @@ export const OidcAdapter = /* @__PURE__ */ (config: OidcConfig) => {
     });
 
     routes.post("/callback", async (c) => {
-      const callback = c.req.url.replace(/authorize$/, "callback");
+      const callback = c.req.url.replace(/authorize\/.*$/, "callback");
       const client = new config.issuer.Client({
         client_id: config.clientID,
         redirect_uris: [callback],


### PR DESCRIPTION
I've been trying to set up github auth, but haven't been able to get it to work without setting the below in the githubadapter.
`params: {
                redirect_uri: 'https://......lambda-url.eu-north-1.on.aws/github/callback',
            },`
            
This PR should fix the issue with the regex so it now matches from `/authorize/` to EOL. Checked [sst/sst](https://github.com/sst/sst/blob/d67d9c99b1882dddb1219a482d4956d66a47c4db/packages/sst/src/node/future/auth/adapter/oauth.ts#L46) so my guess is that this is what should happen