### PR TITLE
fix: allow falsy secret values

### DIFF
--- a/pkg/platform/src/components/secret.ts
+++ b/pkg/platform/src/components/secret.ts
@@ -98,7 +98,7 @@ export class Secret extends Component implements Link.Linkable {
     this._name = name;
     this._placeholder = placeholder;
     const value = process.env["SST_SECRET_" + this._name] ?? this._placeholder;
-    if (!value) {
+    if (typeof value === "undefined") {
       throw new SecretMissingError(this._name);
     }
     this._value = value;

--- a/pkg/platform/src/components/secret.ts
+++ b/pkg/platform/src/components/secret.ts
@@ -98,7 +98,7 @@ export class Secret extends Component implements Link.Linkable {
     this._name = name;
     this._placeholder = placeholder;
     const value = process.env["SST_SECRET_" + this._name] ?? this._placeholder;
-    if (typeof value === "undefined") {
+    if (typeof value !== "string") {
       throw new SecretMissingError(this._name);
     }
     this._value = value;


### PR DESCRIPTION
I'm setting some secrets in my project and I need some placeholder values to be falsy values. For example, when using a db file with SQLite for local development with Drizzle and Turso I want to set the secrets this way:

```ts
new sst.Secret("TursoDatabaseUrl", "file:local.db")
new sst.Secret("TursoDatabaseAuthToken", "")
```

In order to do this

```ts
import { Resource } from "sst"
import type { Config } from "drizzle-kit"

export default {
  // ...
  dbCredentials: {
    url: Resource.TursoDatabaseUrl,
    authToken: Resource.TursoDatabaseAuthToken,
  },
} satisfies Config
```

I'm sure there's a safer way to do this, just trying to kick off the discussion with this PR 🙂