### PR TITLE
Add support for Cloudflare Worker Entrypoints

### DIFF
--- a/pkg/platform/src/components/cloudflare/worker.ts
+++ b/pkg/platform/src/components/cloudflare/worker.ts
@@ -371,7 +371,7 @@ export class Worker extends Component implements Link.Cloudflare.Linkable {
               accountId: sst.cloudflare.DEFAULT_ACCOUNT_ID,
               content: (await fs.readFile(handler)).toString(),
               module: true,
-              compatibilityDate: "2024-01-01",
+              compatibilityDate: "2024-04-04",
               compatibilityFlags: ["nodejs_compat"],
               ...bindings,
               plainTextBindings: [

--- a/pkg/platform/src/runtime/cloudflare.ts
+++ b/pkg/platform/src/runtime/cloudflare.ts
@@ -64,6 +64,10 @@ export async function build(name: string, input: pulumi.Unwrap<WorkerArgs>) {
     sourcemap: false,
     conditions: ["worker"],
     minify: build.minify,
+    external: [
+      ...(build.esbuild?.external ?? []),
+      "cloudflare:workers"
+    ],
     ...build.esbuild,
     banner: {
       js: [build.banner || "", build.esbuild?.banner || ""].join("\n"),

--- a/pkg/platform/src/runtime/cloudflare.ts
+++ b/pkg/platform/src/runtime/cloudflare.ts
@@ -64,11 +64,11 @@ export async function build(name: string, input: pulumi.Unwrap<WorkerArgs>) {
     sourcemap: false,
     conditions: ["worker"],
     minify: build.minify,
+    ...build.esbuild,
     external: [
       ...(build.esbuild?.external ?? []),
       "cloudflare:workers"
     ],
-    ...build.esbuild,
     banner: {
       js: [build.banner || "", build.esbuild?.banner || ""].join("\n"),
     },

--- a/sdk/js/src/resource.ts
+++ b/sdk/js/src/resource.ts
@@ -26,6 +26,15 @@ export function fromCloudflareEnv(input: any) {
 }
 
 export function wrapCloudflareHandler(handler: any) {
+  if (typeof handler === 'function' && handler.hasOwnProperty('prototype')) {
+    return class extends handler {
+      constructor(ctx: any, env: any) {
+        fromCloudflareEnv(env);
+        super(ctx, env)
+      }
+    }
+  }
+
   function wrap(fn: any) {
     return function (req: any, env: any, ...rest: any[]) {
       fromCloudflareEnv(env);


### PR DESCRIPTION
SST currently can't deploy workers exporting the new Cloudflare Worker [RPC entrypoint](https://developers.cloudflare.com/workers/runtime-apis/rpc/) as a class (rather than an object). With the following:

```typescript
// sst.config.ts
/// <reference path="./.sst/platform/config.d.ts" />

export default $config({
	app(input) {
		return {
			name: "cloudflare-worker-entrypoint",
			removal: "retain",
			home: "cloudflare",
		};
	},
    async run() {
      const worker = new sst.cloudflare.Worker("WorkerEntrypointTest", {
        handler: "./index.ts",
        url: true,
      })
});

  return {
    api: worker.url,
  };
}
```

```typescript
// index.ts
import { WorkerEntrypoint } from "cloudflare:workers";

export default class extends WorkerEntrypoint {
  async fetch() { return new Response("Hello from Worker B"); }

  add(a, b) { return a + b; }
}
```

Currently, `sst deploy` fails with the following error:

```bash
×  Failed
   WorkerEntrypointTest sst:cloudflare:Worker → WorkerEntrypointTestScript cloudflare:index:WorkerScript
   error creating worker script: The uploaded script has no registered event handlers. (10068)
 ```

**What this PR does**:

- Allows SST to deploy default entrypoints that extend `WorkerEntrypoint`

**What this PR does not do**:

- Add support for deploying named entrypoint classes.

Perhaps the check for a class could be more accurate, but it seems to work well enough currently. Also modified the Cloudflare runtime so it automatically externalises `cloudflare:workers` so the consumer doesn't need to do so in their SST config.