### PR TITLE
feat: expose VPC config in ssr-site, include permissions when building Next.js plan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,6 +5933,15 @@
         "@pulumi/pulumi": "^3.0.0"
       }
     },
+    "node_modules/@pulumiverse/vercel": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pulumiverse/vercel/-/vercel-1.3.0.tgz",
+      "integrity": "sha512-01MbJ5skedIhZCxL+YHlZeNtkY2ibMrO48Ilgum7x65Uk4xuOLRT9/0zszBPYASJAkE7P+NVOS/pMIROdSNgjA==",
+      "dev": true,
+      "dependencies": {
+        "@pulumi/pulumi": "^3.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.14.0",
       "cpu": [
@@ -16295,6 +16304,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-iot": "3.501.0",
+        "@pulumiverse/vercel": "1.3.0",
         "@tsconfig/node18": "18.2.2",
         "@types/archiver": "6.0.2",
         "@types/aws-lambda": "^8.10.133",

--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -5,7 +5,7 @@ import { globSync } from "glob";
 import { ComponentResourceOptions, Output, all } from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { Size } from "../size.js";
-import { Function } from "./function.js";
+import { Function, FunctionArgs } from "./function.js";
 import {
   Plan,
   SsrSiteArgs,

--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import crypto from "crypto";
 import { globSync } from "glob";
-import { ComponentResourceOptions, Output, all } from "@pulumi/pulumi";
+import { ComponentResourceOptions, Output, all, output } from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { Size } from "../size.js";
 import { Function } from "./function.js";
@@ -716,6 +716,7 @@ export class Nextjs extends Component implements Link.Linkable {
         buildId,
         openNextOutput,
         args?.imageOptimization,
+        args.permissions,
         [bucket.arn, bucket.name],
         revalidationQueue.apply((q) => ({ url: q?.url, arn: q?.arn })),
         revalidationTable.apply((t) => ({ name: t?.name, arn: t?.arn })),
@@ -725,6 +726,7 @@ export class Nextjs extends Component implements Link.Linkable {
           buildId,
           openNextOutput,
           imageOptimization,
+          permissions,
           [bucketArn, bucketName],
           { url: revalidationQueueUrl, arn: revalidationQueueArn },
           { name: revalidationTableName, arn: revalidationTableArn },
@@ -785,6 +787,7 @@ export class Nextjs extends Component implements Link.Linkable {
                     },
                   ]
                 : []),
+              ...(permissions ?? []),
             ],
           };
 

--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -5,7 +5,7 @@ import { globSync } from "glob";
 import { ComponentResourceOptions, Output, all } from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { Size } from "../size.js";
-import { Function, FunctionArgs } from "./function.js";
+import { Function } from "./function.js";
 import {
   Plan,
   SsrSiteArgs,

--- a/pkg/platform/src/components/aws/ssr-site.ts
+++ b/pkg/platform/src/components/aws/ssr-site.ts
@@ -56,6 +56,21 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
   domain?: CdnArgs["domain"];
   permissions?: FunctionArgs["permissions"];
   warm?: Input<number>;
+  /**
+   * The VPC network to place the [server function](#nodes-server) in. This is useful if your function needs to access resources in your VPC.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   vpc: {
+   *     securityGroups: ["mySecurityGroupId"],
+   *     subnets: ["mySubnetId"]
+   *   }
+   * }
+   * ```
+   */
+  vpc?: FunctionArgs["vpc"];
   invalidation?: Input<
     | false
     | {
@@ -542,6 +557,7 @@ function handler(event) {
             ...(props.function.link ?? []),
             ...(link ?? []),
           ]),
+          vpc: args.vpc,
           url: true,
           live: false,
           _ignoreCodeChanges: $dev,


### PR DESCRIPTION
Allowing custom vpc configuration sst/sst#4752 

---

To access the function args before this PR merged, use the `transform` function as below:

```js
new sst.aws.Nextjs("App", {
  transform: {
    server(fn) {
      fn.vpc = {
        subnets: ["..."],
        securityGroups: ["..."],
      };

      fn.permissions = [
        // @ts-expect-error
        ...fn.permissions,
        {
          actions: ["..."],
          resources: ["..."],
        },
      ];
    },
  },
});
```