### PR TITLE
feat: add vpc and related iam perms to Nextjs

### DIFF
--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -336,6 +336,20 @@ export interface NextjsArgs extends SsrSiteArgs {
      */
     memory?: Size;
   };
+  /**
+   * Configure the subnet and security groups for the default Lambda running the Next.js app.
+   *
+   * @example
+   * ```js
+   * {
+   *   vpc: {
+   *     subnetIds: ["subnet-12345678{f", "subnet-98765432"],
+   *     securityGroupIds: ["sg-12345678"]
+   *   }
+   * }
+   * ```
+   */
+  vpc?: SsrSiteArgs["vpc"];
 }
 
 /**
@@ -782,6 +796,21 @@ export class Nextjs extends Component implements Link.Linkable {
                         revalidationTableArn,
                         `${revalidationTableArn}/*`,
                       ],
+                    },
+                  ]
+                : []),
+              // allow lambda to connect to vpc/subnets
+              ...(args.vpc
+                ? [
+                    {
+                      actions: [
+                        "ec2:DescribeNetworkInterfaces",
+                        "ec2:CreateNetworkInterface",
+                        "ec2:DeleteNetworkInterface",
+                        "ec2:DescribeInstances",
+                        "ec2:AttachNetworkInterface",
+                      ],
+                      resources: ["*"],
                     },
                   ]
                 : []),

--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -343,8 +343,8 @@ export interface NextjsArgs extends SsrSiteArgs {
    * ```js
    * {
    *   vpc: {
-   *     subnetIds: ["subnet-12345678{f", "subnet-98765432"],
-   *     securityGroupIds: ["sg-12345678"]
+   *     subnets: ["subnet-12345678{f", "subnet-98765432"],
+   *     securityGroups: ["sg-12345678"]
    *   }
    * }
    * ```

--- a/pkg/platform/src/components/aws/ssr-site.ts
+++ b/pkg/platform/src/components/aws/ssr-site.ts
@@ -55,6 +55,7 @@ export type Plan = ReturnType<typeof validatePlan>;
 export interface SsrSiteArgs extends BaseSsrSiteArgs {
   domain?: CdnArgs["domain"];
   permissions?: FunctionArgs["permissions"];
+  vpc?: FunctionArgs["vpc"];
   warm?: Input<number>;
   invalidation?: Input<
     | false
@@ -521,6 +522,7 @@ function handler(event) {
         `${name}${sanitizeToPascalCase(fnName)}`,
         transform(args.transform?.server, {
           description: `${name} server`,
+          vpc: args.vpc,
           runtime: "nodejs20.x",
           timeout: "20 seconds",
           permissions: args.permissions,


### PR DESCRIPTION
Add `vpc` configuration option to `sst.aws.Nextjs` so that the server code in next.js can access resources in the vpc, see sst/sst#4752 .

eg

```
    new sst.aws.Nextjs(NEXTJS_COMPONENT_NAME, {
      domain,
      environment,
      // vpc requires experimental version
      vpc: {
        securityGroups: ["sg-123455678"],
        subnets: ["subnet-12345678", "subnet-87654321", "subnet-23456789"],
      },
    });
```

I've tested this by building `sst` binary (using `goreleaser` etc) on this branch and deploying it to our dev environment.  The next.js server code needs to hit elasticache through our vpc.  I've checked in AWS to verify the VPC for the "default" lambda running next js and its execution role were updated with the permission.

There's another P/R from @kane50613  sst/ion#266 .  We were both wanting to get this to happen.