### PR TITLE
Fix wrong type for Function layers

### DIFF
--- a/pkg/platform/src/components/aws/function.ts
+++ b/pkg/platform/src/components/aws/function.ts
@@ -737,7 +737,7 @@ export interface FunctionArgs {
    * }
    * ```
    */
-  layers?: Input<string[]>;
+  layers?: Input<Input<string>[]>;
   /**
    * Configure the function to connect to private subnets in a virtual private cloud or VPC. This allows your function to access private resources.
    *


### PR DESCRIPTION
When working with lambda layers the `arn` property will be an `Output` type so we must allow an `Output` array or an array of `Output`