### PR TITLE
docs(aws/static-site): minor typing issue

### DIFF
--- a/pkg/platform/src/components/aws/static-site.ts
+++ b/pkg/platform/src/components/aws/static-site.ts
@@ -123,7 +123,7 @@ export interface StaticSiteArgs extends BaseStaticSiteArgs {
    * :::tip
    * You get 1000 free invalidations per month. After that you pay $0.005 per invalidation path. [Read more here](https://aws.amazon.com/cloudfront/pricing/).
    * :::
-   * @default `&lcub;paths: "all", wait: false&rcub;`
+   * @default `{ paths: "all", wait: false }`
    * @example
    * Turn off invalidations.
    * ```js


### PR DESCRIPTION
Should not be HTML entity in Markdown `code` element

![image](https://github.com/sst/ion/assets/23612546/88c80932-b804-4079-825e-3427039838fd)