### PR TITLE
Email Fix: Throw Error when DNS is set but not a Domain

### DIFF
--- a/pkg/platform/src/components/aws/email.ts
+++ b/pkg/platform/src/components/aws/email.ts
@@ -151,7 +151,7 @@ export class Email
 
     function normalizeDns() {
       all([args.dns, isDomain]).apply(([dns, isDomain]) => {
-        if (isDomain && dns)
+        if (dns && !isDomain)
           throw new Error(
             `The "dns" property is only valid when "sender" is a domain.`,
           );


### PR DESCRIPTION
This change adjusts the conditional checks for the AWS Email construct to match the error message:
> The "dns" property is only valid when "sender" is a domain

This came up while I was attempting to verify a domain:
```javascript
export const emailDomain = new sst.aws.Email('Domain', {
    sender: 'my.sub.domain',
    dns: sst.aws.dns({ zone: rootZone.id }),
})
```