### PR TITLE
docs: aws-swift typos

### DIFF
--- a/examples/aws-swift/README.md
+++ b/examples/aws-swift/README.md
@@ -6,7 +6,7 @@ Deploy Swift applications using sst ion.
 
 Building your application for deployment requires installing Docker.
 
-When deploying with `sst deploy` your application will be build for Amazon Linux, ensuring its campatible with the AWS Lambda provided runtime.
+When deploying with `sst deploy` your application will be build for Amazon Linux, ensuring its compatible with the AWS Lambda provided runtime.
 
 ## Deploy
 

--- a/examples/aws-swift/sst.config.ts
+++ b/examples/aws-swift/sst.config.ts
@@ -5,7 +5,7 @@ const swiftVersion = "5.10";
 /**
  * ## Swift on Lambda
  *
- * Deploys a simple Swift applicaiton to Lambda using the `al2023` runtime.
+ * Deploys a simple Swift application to Lambda using the `al2023` runtime.
  *
  * :::note
  * Building this function requires Docker.


### PR DESCRIPTION
updates `applicaiton` → `application` on this page: https://ion.sst.dev/docs/examples/#swift-on-lambda

<img width="622" alt="Screenshot 2024-05-03 at 9 22 56 PM" src="https://github.com/sst/ion/assets/3117665/125cf9d4-9320-465e-91ac-3046e1f48087">

updates `campatible` → `compatible` in the example README.