### PR TITLE
fix(aws/https-redirect) default viewer certificate TLS to version 1.2

### DIFF
--- a/pkg/platform/src/components/aws/https-redirect.ts
+++ b/pkg/platform/src/components/aws/https-redirect.ts
@@ -88,6 +88,7 @@ export class HttpsRedirect extends Component {
         viewerCertificate: {
           acmCertificateArn: certificate.arn,
           sslSupportMethod: "sni-only",
+          minimumProtocolVersion: "TLSv1.2_2021",
         },
         defaultCacheBehavior: {
           allowedMethods: ["GET", "HEAD", "OPTIONS"],


### PR DESCRIPTION
Sets the TLS version to 1.2 (recommended) for the https redirect distribution. This matches the default for the base cdn distribution as well. 

Previously was falling back to TLS 1.0 as the default