### PR TITLE
installer: add support for ash shell in alpine linux

### DIFF
--- a/install
+++ b/install
@@ -96,7 +96,7 @@ download_and_install
 add_to_path() {
     local config_file=$1
     local command=$2
-    
+
     if [[ -w $config_file ]]; then
         echo -e "\n# sst" >> "$config_file"
         echo "$command" >> "$config_file"
@@ -119,6 +119,9 @@ case $current_shell in
     ;;
     bash)
         config_files="$HOME/.bashrc $HOME/.bash_profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+    ;;
+    ash)
+        config_files="$HOME/.ashrc $HOME/.profile /etc/profile"
     ;;
     *)
         # Default case if none of the above matches
@@ -148,6 +151,9 @@ if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
             add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
         ;;
         bash)
+            add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+        ;;
+        ash)
             add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
         ;;
         *)


### PR DESCRIPTION
Should resolve sst/sst#4719 

Since alpine might not come with an `.ashrc` or `.profile` by default, depending on the distro, it would still be up to the user to `touch ~/.ashrc && touch ~/.profile` if running this in a fresh CI environment. 