### PR TITLE
fix aws lambda dev bootstrap not always targeting linux amd64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ project_name: sst
 before:
   hooks:
     - go mod tidy
-    - go build -o ./pkg/platform/dist/bridge/bootstrap ./pkg/platform/bridge
+    - bash -c 'GOARCH=amd64 GOOS=linux go build -o ./pkg/platform/dist/bridge/bootstrap ./pkg/platform/bridge'
     - bash -c 'cd ./pkg/platform && ./scripts/build-functions'
     - go test ./cmd/... ./pkg/...
 builds:


### PR DESCRIPTION
Dev was broken in local dev on mac, this seems to fix it.

The `sst dev` `bootstrap` lambda needs to always target the aws lambda runtime, not detect based on the local machine. 