### PR TITLE
fix child processes becoming zombies in dev

### DIFF
--- a/internal/util/util_darwin.go
+++ b/internal/util/util_darwin.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_darwin.go
+func TerminateProcess(pid int) error {
+	// Signal the process group (-pid), not just the process, so that the process
+	// and all its children are signaled. Else, child procs can keep running and
+	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_darwin.go
+func SetProcessGroupID(cmd *exec.Cmd) {
+	// Set process group ID so the cmd and all its children become a new
+	// process group. This allows Stop to SIGTERM the cmd's process group
+	// without killing this process (i.e. this code here).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/util/util_freebsd.go
+++ b/internal/util/util_freebsd.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_freebsd.go
+func TerminateProcess(pid int) error {
+	// Signal the process group (-pid), not just the process, so that the process
+	// and all its children are signaled. Else, child procs can keep running and
+	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_freebsd.go
+func SetProcessGroupID(cmd *exec.Cmd) {
+	// Set process group ID so the cmd and all its children become a new
+	// process group. This allows Stop to SIGTERM the cmd's process group
+	// without killing this process (i.e. this code here).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/util/util_linux.go
+++ b/internal/util/util_linux.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_linux.go
+func TerminateProcess(pid int) error {
+	// Signal the process group (-pid), not just the process, so that the process
+	// and all its children are signaled. Else, child procs can keep running and
+	// keep the stdout/stderr fd open and cause cmd.Wait to hang.
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_linux.go
+func SetProcessGroupID(cmd *exec.Cmd) {
+	// Set process group ID so the cmd and all its children become a new
+	// process group. This allows Stop to SIGTERM the cmd's process group
+	// without killing this process (i.e. this code here).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/util/util_windows.go
+++ b/internal/util/util_windows.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_windows.go
+func TerminateProcess(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}
+
+// https://github.com/go-cmd/cmd/blob/master/cmd_windows.go
+func SetProcessGroupID(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+}


### PR DESCRIPTION
fixes sst/sst#4706 

TL;DR I was using volta, which spawns node in a child process & it wasn't getting cleaned up.

This pr attempts to address that by always cleaning up the process & all sub-processes. To do so I lifted some code from [go-cmd](https://github.com/go-cmd/cmd/blob/master/cmd_linux.go).

I didn't try very hard on the naming/factoring - happy to change it to whatever y'all prefer

Not sure if it could be used in more places too - noticed something similar in client already:

https://github.com/sst/ion/blob/11e5f33cb057ac36615073e055893c65b1c97b69/pkg/server/client.go#L41