### PR TITLE
Add sst install command to steps

### DIFF
--- a/www/src/content/docs/docs/start/aws/nextjs.mdx
+++ b/www/src/content/docs/docs/start/aws/nextjs.mdx
@@ -35,6 +35,16 @@ sst init
 
 This'll detect that you are in a Next.js project and create a `sst.config.ts` file in the root.
 
+#### Install Providers
+
+Now let's install the SST providers required for our app.
+
+```bash
+sst install
+```
+
+This'll detect the providers required for our Next.js app that have been defined in `sst.config.ts` and install them.
+
 #### Start dev mode
 
 Start the dev mode for your Next.js app and link it to SST.


### PR DESCRIPTION
Not sure if I missed a step elsewhere but I needed to run sst install after sst init, in order for a new Next.js app to successfully launch in dev mode, following the steps in this example.