### PR TITLE
aws-dart-api example

### DIFF
--- a/examples/aws-dart-api/.gitignore
+++ b/examples/aws-dart-api/.gitignore
@@ -1,0 +1,10 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+
+# sst
+.sst

--- a/examples/aws-dart-api/CHANGELOG.md
+++ b/examples/aws-dart-api/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/examples/aws-dart-api/README.md
+++ b/examples/aws-dart-api/README.md
@@ -1,0 +1,107 @@
+# ❍ AWS Dart API Example
+
+Deploy a Dart API on AWS using SST ION.
+
+**IMPORTANT:** Docker must be installed to use this approach.
+
+This project was initiated as a standard Dart package, and then SST was initialized using the command:
+
+```bash
+sst init
+```
+
+The **aws_lambda_dart_runtime** package was added to the project using the katallaxie GitHub fork:
+
+```yaml
+dependencies:
+  aws_lambda_dart_runtime:
+    git:
+      url: https://github.com/katallaxie/aws-lambda-dart-runtime
+```
+
+In the `lib/src/main.dart` a simple hello-world function named `hello` has been registered to the `Runtime` singleton:
+
+```dart
+import 'package:aws_lambda_dart_runtime/aws_lambda_dart_runtime.dart';
+import 'package:aws_lambda_dart_runtime/runtime/context.dart';
+
+void main() async {
+  /// This demo's handling an API Gateway request.
+  hello(Context context, AwsApiGatewayEvent event) async {
+    final response = {
+      "message": "Hello from Dart!",
+    };
+    return AwsApiGatewayResponse.fromJson(response);
+  }
+
+  /// The Runtime is a singleton. You can define the handlers as you wish.
+  Runtime()
+    ..registerHandler<AwsApiGatewayEvent>(
+      'hello',
+      hello,
+    )
+    ..invoke();
+}
+```
+
+Inside root folder a `build.sh` file was created with the necessary commands to compile the Linux binary:
+
+```bash
+#!/bin/sh
+
+# Install dependencies
+dart pub get
+
+# build the binary
+dart compile exe bin/main.dart -o dist/bootstrap
+
+# Exit
+exit
+```
+
+Lastly, the `sst.config.ts` file was modified to create the API:
+
+```typescript
+/// <reference path="./.sst/platform/config.d.ts" />
+
+export default $config({
+  app(input) {
+    return {
+      name: "aws-dart-api",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const api = new sst.aws.ApiGatewayV2("MyApi");
+    api.route("GET /", {
+      runtime: "provided.al2023",
+      architecture: process.arch === "arm64" ? "arm64" : "x86_64",
+      bundle: build(),
+      handler: "hello",
+    });
+  },
+});
+
+function build() {
+  require("child_process").execSync(`
+mkdir -p .build
+docker run -v $PWD:/app -w /app --entrypoint ./build.sh dart:stable-sdk
+`);
+  return `.build/`;
+}
+```
+
+## Build
+
+Building your application for deployment requires installing Docker.
+
+When deploying with `sst deploy`, your application will be built for Amazon Linux, ensuring it's compatible with the AWS Lambda provided runtime.
+
+## Deploy
+
+Deploy just like any other sst project:
+
+```sh
+sst deploy --stage production
+```

--- a/examples/aws-dart-api/analysis_options.yaml
+++ b/examples/aws-dart-api/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/examples/aws-dart-api/build.sh
+++ b/examples/aws-dart-api/build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Install dependencies
+dart pub get
+
+# build the binary
+dart compile exe lib/src/main.dart -o .build/bootstrap
+
+# Exit
+exit

--- a/examples/aws-dart-api/lib/src/main.dart
+++ b/examples/aws-dart-api/lib/src/main.dart
@@ -1,0 +1,20 @@
+import 'package:aws_lambda_dart_runtime/aws_lambda_dart_runtime.dart';
+import 'package:aws_lambda_dart_runtime/runtime/context.dart';
+
+void main() async {
+  /// This demo's handling an API Gateway request.
+  hello(Context context, AwsApiGatewayEvent event) async {
+    final response = {
+      "message": "Hello from Dart!",
+    };
+    return AwsApiGatewayResponse.fromJson(response);
+  }
+
+  /// The Runtime is a singleton. You can define the handlers as you wish.
+  Runtime()
+    ..registerHandler<AwsApiGatewayEvent>(
+      'hello',
+      hello,
+    )
+    ..invoke();
+}

--- a/examples/aws-dart-api/pubspec.yaml
+++ b/examples/aws-dart-api/pubspec.yaml
@@ -1,0 +1,16 @@
+name: aws_dart_api
+description: A starting point for an AWS Serverless Api using Dart and SST ION.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.4.0
+
+dependencies:
+  aws_lambda_dart_runtime:
+    git:
+      url: https://github.com/katallaxie/aws-lambda-dart-runtime
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0

--- a/examples/aws-dart-api/sst.config.ts
+++ b/examples/aws-dart-api/sst.config.ts
@@ -1,0 +1,28 @@
+/// <reference path="./.sst/platform/config.d.ts" />
+
+export default $config({
+  app(input) {
+    return {
+      name: "aws-dart-api",
+      removal: input?.stage === "production" ? "retain" : "remove",
+      home: "aws",
+    };
+  },
+  async run() {
+    const api = new sst.aws.ApiGatewayV2("MyApi");
+    api.route("GET /", {
+      runtime: "provided.al2023",
+      architecture: process.arch === "arm64" ? "arm64" : "x86_64",
+      bundle: build(),
+      handler: "hello",
+    });
+  },
+});
+
+function build() {
+  require("child_process").execSync(`
+mkdir -p .build
+docker run -v $PWD:/app -w /app --entrypoint ./build.sh dart:stable-sdk
+`);
+  return `.build/`;
+}


### PR DESCRIPTION
Adds a new example for deploying an AWS API with ION using Dart.

Deployed here: https://2zne28kl7c.execute-api.us-east-1.amazonaws.com/