### PR TITLE
fix: remix action/loaders with redirect timeout

### DIFF
--- a/pkg/platform/functions/remix-server/regional-server.mjs
+++ b/pkg/platform/functions/remix-server/regional-server.mjs
@@ -123,8 +123,8 @@ const createApigHandler = (build) => {
       await streamToNodeStream(response.body.getReader(), responseStream);
     } else {
       writer.write(" ");
-      writer.end();
     }
+      writer.end();
   });
 };
 

--- a/pkg/platform/functions/remix-server/regional-server.mjs
+++ b/pkg/platform/functions/remix-server/regional-server.mjs
@@ -113,13 +113,16 @@ const createApigHandler = (build) => {
         "Transfer-Encoding": "chunked",
       },
     };
-    if (response.body) {
-      const reader = response.body;
-      const writer = awslambda.HttpResponseStream.from(
+
+    const writer = awslambda.HttpResponseStream.from(
         responseStream,
         httpResponseMetadata,
-      );
-      await streamToNodeStream(reader.getReader(), responseStream);
+    );
+
+    if (response.body) {
+      await streamToNodeStream(response.body.getReader(), responseStream);
+    } else {
+      writer.write(" ");
       writer.end();
     }
   });


### PR DESCRIPTION
fixes sst/sst#4646

this issue is due to the [react-router redirect function](https://github.com/remix-run/react-router/blob/9d42655bc6eedd9a09d0c82c48406c8d9268260f/packages/router/utils.ts#L1542) that remix uses not including a body (as it's just a redirect, so is only setting headers)

streamified response with empty body ignores other response attributes, so we write a single whitespace