### PR TITLE
Add redirect_uri and and response_type to success callback

### DIFF
--- a/sdk/js/src/auth/handler.ts
+++ b/sdk/js/src/auth/handler.ts
@@ -8,6 +8,8 @@ import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 
 interface OnSuccessResponder<T extends { type: any; properties: any }> {
   session(input: T & JWTPayload): Promise<Response>;
+  redirect_uri?: string;
+  response_type?: string;
 }
 
 export class UnknownProviderError extends Error {
@@ -147,8 +149,10 @@ export function AuthHandler<
     },
     algorithm: "RS512",
     async success(ctx: Context, properties: any) {
-      const redirect_uri = getCookie(ctx, "redirect_uri");
-      const response_type = getCookie(ctx, "response_type");
+      const redirect_uri =
+        ctx.req.query("redirect_uri") || getCookie(ctx, "redirect_uri");
+      const response_type =
+        ctx.req.query("response_type") || getCookie(ctx, "response_type");
       if (!redirect_uri) {
         return options.forward(
           ctx,
@@ -201,6 +205,8 @@ export function AuthHandler<
             ctx.status(400);
             return ctx.text(`Unsupported response_type: ${response_type}`);
           },
+          redirect_uri,
+          response_type
         },
         {
           provider: ctx.get("provider"),


### PR DESCRIPTION
Prior to this, the success callback provided three things:

an object that holds the session function for creating a new token and redirecting back with the token in the hash,
The input that holds the provider, the tokenset and the oauth client
the raw request
This PR adds the redirect_uri and response_type to the first object alongside the session function. It also tries to get these values from the query params as an alternative to the getCookie helper.

The reason I'd like this to be added is because the session function is doing too many things for my usecase. In a Next.js application, I have an API route that acts as my final callback to the front end. This API route is server side and does not expose the hash on the Request object. The flow is like this:

SST Auth lambda redirects to [www.frontend.com/callback#access_token=abcd1234](http://www.frontend.com/callback#access_token=abcd1234) ----> Next API Route picks up the request and loses the access_token because the hash is never sent to the server. I believe that is just part of the HTML spec.

If we can also expose the redirect_uri and response_type here, I can do the redirect in my app without using the session function. I'd be able to append the access_token as a query parameter which does persist between across to the server.

The alternative to this PR is changing how the session function works and instead of appending the access token and state to the hash, we append it as a query parameter.