### PR TITLE
Strip `SST_RESOURCE_` prefix from cloudflare env

### DIFF
--- a/sdk/js/src/resource.ts
+++ b/sdk/js/src/resource.ts
@@ -24,7 +24,8 @@ export function fromCloudflareEnv(input: any) {
         value = JSON.parse(value);
       } catch {}
     }
-    raw[key] = value;
+    const envKey = key.startsWith('SST_RESOURCE_') ? key.slice("SST_RESOURCE_".length) : key
+    raw[envKey] = value;
   }
 }
 


### PR DESCRIPTION
Closes [`#438`](https://github.com/sst/sst/issues/4613) - just stripping the `SST_RESOURCE_` prefix like it already does. Will require a new release of the npm package.