### PR TITLE
fix: return valid arn from createTriggers function

### DIFF
--- a/examples/aws-cognito/index.ts
+++ b/examples/aws-cognito/index.ts
@@ -1,0 +1,1 @@
+export async function handler() {}

--- a/examples/aws-cognito/sst.config.ts
+++ b/examples/aws-cognito/sst.config.ts
@@ -9,7 +9,13 @@ export default $config({
     };
   },
   async run() {
-    const userPool = new sst.aws.CognitoUserPool("MyUserPool");
+    const userPool = new sst.aws.CognitoUserPool("MyUserPool", {
+      triggers: {
+        preSignUp: {
+          handler: "index.handler",
+        },
+      },
+    });
     const client = userPool.addClient("Web");
     const identityPool = new sst.aws.CognitoIdentityPool("MyIdentityPool", {
       userPools: [

--- a/pkg/platform/src/components/aws/cognito-user-pool.ts
+++ b/pkg/platform/src/components/aws/cognito-user-pool.ts
@@ -212,7 +212,7 @@ export class CognitoUserPool
                 description: `Subscribed to ${trigger} from ${name}`,
               }
             );
-            return [trigger, fn];
+            return [trigger, fn.arn];
           })
         )
       );

--- a/pkg/platform/src/components/aws/cognito-user-pool.ts
+++ b/pkg/platform/src/components/aws/cognito-user-pool.ts
@@ -177,7 +177,7 @@ export class CognitoUserPool
   constructor(
     name: string,
     args: CognitoUserPoolArgs = {},
-    opts?: ComponentResourceOptions
+    opts?: ComponentResourceOptions,
   ) {
     super(__pulumiType, name, args, opts);
 
@@ -194,7 +194,7 @@ export class CognitoUserPool
       all([args.aliases, args.usernames]).apply(([aliases, usernames]) => {
         if (aliases && usernames) {
           throw new VisibleError(
-            "You cannot set both aliases and usernames. Learn more about customizing sign-in attributes at https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#user-pool-settings-aliases"
+            "You cannot set both aliases and usernames. Learn more about customizing sign-in attributes at https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html#user-pool-settings-aliases",
           );
         }
       });
@@ -211,11 +211,13 @@ export class CognitoUserPool
               value,
               {
                 description: `Subscribed to ${trigger} from ${name}`,
-              }
+              },
+              undefined,
+              { parent },
             );
             return [trigger, fn.arn];
-          })
-        )
+          }),
+        ),
       );
     }
 
@@ -277,20 +279,20 @@ export class CognitoUserPool
           },
           lambdaConfig: triggers,
         }),
-        { parent }
+        { parent },
       );
     }
-    
+
     function createPermissions() {
       if (!triggers) return;
 
       triggers.apply((triggers) => {
-        Object.entries(triggers).forEach(([trigger, triggerArn]) => {
+        Object.entries(triggers).forEach(([trigger, functionArn]) => {
           new aws.lambda.Permission(
-            `${name}InvokePermission${trigger}`,
+            `${name}Permission${trigger}`,
             {
               action: "lambda:InvokeFunction",
-              function: triggerArn,
+              function: functionArn,
               principal: "cognito-idp.amazonaws.com",
               sourceArn: userPool.arn,
             },

--- a/pkg/platform/src/components/aws/cognito-user-pool.ts
+++ b/pkg/platform/src/components/aws/cognito-user-pool.ts
@@ -186,6 +186,7 @@ export class CognitoUserPool
     normalizeAliasesAndUsernames();
     const triggers = createTriggers();
     const userPool = createUserPool();
+    createPermissions();
 
     this.userPool = userPool;
 
@@ -278,6 +279,25 @@ export class CognitoUserPool
         }),
         { parent }
       );
+    }
+    
+    function createPermissions() {
+      if (!triggers) return;
+
+      triggers.apply((triggers) => {
+        Object.entries(triggers).forEach(([trigger, triggerArn]) => {
+          new aws.lambda.Permission(
+            `${name}InvokePermission${trigger}`,
+            {
+              action: "lambda:InvokeFunction",
+              function: triggerArn,
+              principal: "cognito-idp.amazonaws.com",
+              sourceArn: userPool.arn,
+            },
+            { parent },
+          );
+        });
+      });
     }
   }
 


### PR DESCRIPTION
fixes issue [#361](https://github.com/sst/sst/issues/4673) 

createTriggers function in file .sst/platform/src/components/aws/cognito-user-pool.ts currently returns full function object.

The triggers are then directly passed to the lambdaConfig properties on line 278. 
However, this property is expecting the arn value. Fix returns this value instead.

Cognito doesn't automatically have permission to invoke the trigger functions. So new permissions policies have to be created for each of the functions after the pool has been created
