### PR TITLE
wrong type in cluster vpc example

### DIFF
--- a/pkg/platform/src/components/aws/cluster.ts
+++ b/pkg/platform/src/components/aws/cluster.ts
@@ -119,7 +119,7 @@ export interface ClusterArgs {
    * ```js
    * {
    *   vpc: {
-   *     id: ["vpc-0d19d2b8ca2b268a1"],
+   *     id: "vpc-0d19d2b8ca2b268a1",
    *     publicSubnets: ["subnet-0b6a2b73896dc8c4c", "subnet-021389ebee680c2f0"],
    *     privateSubnets: ["subnet-0db7376a7ad4db5fd ", "subnet-06fc7ee8319b2c0ce"],
    *     securityGroups: ["sg-0399348378a4c256c"],

--- a/www/src/content/docs/docs/component/aws/cluster.mdx
+++ b/www/src/content/docs/docs/component/aws/cluster.mdx
@@ -137,7 +137,7 @@ The VPC to use for the cluster.
 ```js
 {
   vpc: {
-    id: ["vpc-0d19d2b8ca2b268a1"],
+    id: "vpc-0d19d2b8ca2b268a1",
     publicSubnets: ["subnet-0b6a2b73896dc8c4c", "subnet-021389ebee680c2f0"],
     privateSubnets: ["subnet-0db7376a7ad4db5fd ", "subnet-06fc7ee8319b2c0ce"],
     securityGroups: ["sg-0399348378a4c256c"],


### PR DESCRIPTION
type should be `string` instead of `string[]`