### PR TITLE
Docs: add a callout for $app global

### DIFF
--- a/www/src/content/docs/docs/reference/config.mdx
+++ b/www/src/content/docs/docs/reference/config.mdx
@@ -348,4 +348,22 @@ This will display the following in the CLI.
 bucket: bucket-jOaikGu4rla
 ```
 </Segment>
+### $app
+<Segment>
+
+A global variable that can be used in config in order to get access to the name of the app, the stage or the removal settings or the resources.
+
+
+```ts
+async run() {
+  new sst.aws.Nextjs("MyWeb", {
+    domain:
+      $app.stage === "production"
+        ? "example.com"
+        : `${$app.stage}-${$app.name}.example.com`,
+  });
+}
+```
+
+</Segment>
 </div>


### PR DESCRIPTION
I couldn't find the `$app` global and ended up asking in discord. I thought it might be nice to add a mention in the docs.

<img width="1476" alt="Screenshot 2024-05-23 at 1 29 42 PM" src="https://github.com/sst/ion/assets/557689/a225f70a-0604-413e-ba09-da8673949b1a">
