### PR TITLE
fix: Add missing `responseStream` argument to streaming handler

### DIFF
--- a/pkg/platform/src/components/aws/function.ts
+++ b/pkg/platform/src/components/aws/function.ts
@@ -1202,7 +1202,7 @@ export class Function
               content: streaming
                 ? [
                     linkInjection,
-                    `export const ${newHandlerFunction} = awslambda.streamifyResponse(async (event, context) => {`,
+                    `export const ${newHandlerFunction} = awslambda.streamifyResponse(async (event, responseStream, context) => {`,
                     ...injections,
                     `  const { ${oldHandlerFunction}: rawHandler} = await import("./${oldHandlerFileName}${newHandlerFileExt}");`,
                     `  return rawHandler(event, context);`,


### PR DESCRIPTION
Fixes broken `warm` functionality with streaming functions.

When the `warm` function is added to an SSR site it injects this code, which errors without this PR: https://github.com/sst/ion/blob/7d3837cc196bfe19b2e54c1004d8b5bff03b2c8c/pkg/platform/src/components/aws/ssr-site.ts#L719-L720