### PR TITLE
fix:AWS Function handler wrapper should honor path for nested handlers

### DIFF
--- a/pkg/platform/src/components/aws/function.ts
+++ b/pkg/platform/src/components/aws/function.ts
@@ -1197,8 +1197,7 @@ export class Function
               `${newHandlerFileName}.${newHandlerFunction}`,
             ),
             wrapper: {
-              dir: handlerDir,
-              name: `${newHandlerFileName}.mjs`,
+              name: path.posix.join(handlerDir, `${newHandlerFileName}.mjs`),
               content: streaming
                 ? [
                     linkInjection,


### PR DESCRIPTION
The existing code adds a `dir` value to the returned `wrapper` object. This property was never read or used. The result is that if the original handler is in a deep path (i.e. `build/server.mjs`) the wrapper handler (i.e. `index-server.mjs`) is placed at the root of the function code archive, but the `handler` property of the function is set to `build/index-server.mjs` which doesn't exist. The function immediately errors on invocation.

The `wrapper` object is used as input to an archiver, which supports full paths as part of the `name` key.  This PR removes the `dir` key from the wrapper and prepends the path to the `name` key instead. 

An alternative solution would be to keep the wrapper handler (i.e. `index-server.mjs`) at the root level, and modify the `handler` property and the original handler import path to point to the proper paths.