### PR TITLE
Allow CORS override for Auth function url

### DIFF
--- a/pkg/platform/src/components/aws/auth.ts
+++ b/pkg/platform/src/components/aws/auth.ts
@@ -31,7 +31,7 @@ export class Auth extends Component implements Link.Linkable {
     this._authenticator = output(args.authenticator).apply((args) => {
       return new Function(`${name}Authenticator`, {
         ...args,
-        url: true,
+        url: args.url || true,
         streaming: !$dev,
         environment: {
           ...args.environment,


### PR DESCRIPTION
In order to get the code adapter working I had to include the credentials in the `/callback` fetch request, but the browser will error if the allowed origins is set to '*'. This change allowed me to do the following:

```javascript
const auth = new sst.aws.Auth("Auth", {
  authenticator: {
    handler: "./infra/auth.handler",
    url: {
      cors: {
        allowCredentials: true,
        allowHeaders: ["content-type"],
        allowMethods: ["*"],
        allowOrigins: ["http://localhost:3000"]
      }
    },
  },
});
```

**Note:** the Auth function _must_ have a url so if you tried to pass `false` it would still be true.

Fixes sst/sst#4555 