### PR TITLE
Make CognitoUserPool arn public

### DIFF
--- a/pkg/platform/src/components/aws/cognito-user-pool.ts
+++ b/pkg/platform/src/components/aws/cognito-user-pool.ts
@@ -311,6 +311,13 @@ export class CognitoUserPool
   }
 
   /**
+   * The Cognito user pool ARN.
+   */
+  public get arn() {
+    return this.userPool.arn;
+  }
+
+  /**
    * The underlying [resources](/docs/components/#nodes) this component creates.
    */
   public get nodes() {


### PR DESCRIPTION
This makes the arn for CognitoUserPool public so it can be used in things like lambda permissions.