### PR TITLE
Fix aws-monorepo example script types and core index export

### DIFF
--- a/examples/aws-monorepo/packages/core/package.json
+++ b/examples/aws-monorepo/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@aws-monorepo/core",
   "version": "0.0.0",
   "exports": {
+    ".": "./src/index.ts",
     "./*": [
       "./src/*/index.ts",
       "./src/*.ts"

--- a/examples/aws-monorepo/packages/scripts/sst-env.d.ts
+++ b/examples/aws-monorepo/packages/scripts/sst-env.d.ts
@@ -1,1 +1,3 @@
-/// <reference path="../../.sst/types.generated.ts" />
+/* tslint:disable */
+/* eslint-disable */
+/// <reference path="../../sst-env.d.ts" />


### PR DESCRIPTION
I started building yesterday off the latest aws-monorepo example and noticed the scripts folder sst-env.d.ts was still pointing to the old type file.

I also noticed I couldn't import from a packages/core/src/index.ts file without adding an entry to the exports in package.json. 

Thanks!