### PR TITLE
fix: make SsrSite server cache policy maxTtl 1 year

### DIFF
--- a/pkg/platform/src/components/aws/ssr-site.ts
+++ b/pkg/platform/src/components/aws/ssr-site.ts
@@ -676,7 +676,7 @@ function handler(event) {
           {
             comment: "SST server response cache policy",
             defaultTtl: 0,
-            maxTtl: 365,
+            maxTtl: 31536000, // 1 year
             minTtl: 0,
             parametersInCacheKeyAndForwardedToOrigin: {
               cookiesConfig: {


### PR DESCRIPTION
Makes SsrSite's server cache policy `maxTtl` 1 year in seconds. Based on the 365 value, I think this was the intent, just the wrong unit.