### PR TITLE
fix: Sharp bundling install issue

### DIFF
--- a/pkg/platform/src/runtime/node.ts
+++ b/pkg/platform/src/runtime/node.ts
@@ -162,7 +162,7 @@ export async function build(
       const cmd = ["npm install"];
       if (installPackages.includes("sharp")) {
         cmd.push(
-          "--platform=linux",
+          "--os=linux --libc=glibc",
           input.architecture === "arm64" ? "--arch=arm64" : "--arch=x64",
         );
       }


### PR DESCRIPTION
The platform filter was in correct for npm thus it wasn't installing the optional dependencies for the new `@img/sharp_*` prebuilts but was actually installing the current platform specific ones (eg Darwin if running on Mac OS). Swapping to the os and libc flags fixes the issue as recommended in https://sharp.pixelplumbing.com/install#npm-v10

Fixes https://github.com/sst/sst/issues/4811 