### PR TITLE
fix(node): support `@node-rs/*` package

### DIFF
--- a/pkg/platform/src/runtime/node.ts
+++ b/pkg/platform/src/runtime/node.ts
@@ -52,7 +52,16 @@ export async function build(
     .join(path.posix.sep);
 
   // Rebuilt using existing esbuild context
-  const forceExternal = ["sharp", "pg-native"];
+  const forceExternal = [
+    "sharp",
+    "pg-native",
+    "@node-rs/argon2",
+    "@node-rs/bcrypt",
+    "@node-rs/crc32",
+    "@node-rs/jsonwebtoken",
+    "@node-rs/jieba",
+    "@node-rs/xxhash",
+  ];
   const { external, ...override } = nodejs.esbuild || {};
   const links = Object.fromEntries(
     input.links?.map((item) => [item.name, item.properties]) || [],
@@ -160,7 +169,10 @@ export async function build(
         }),
       );
       const cmd = ["npm install"];
-      if (installPackages.includes("sharp")) {
+      if (
+        installPackages.includes("sharp") || 
+        installPackages.some((x) => x.startsWith("@node-rs"))
+      ) {
         cmd.push(
           "--platform=linux",
           input.architecture === "arm64" ? "--arch=arm64" : "--arch=x64",


### PR DESCRIPTION
## Problem
i am deploying a Remix app using SST. i am using [oslo](https://github.com/pilcrowonpaper/oslo) to incorporate `Bcrypt` and `Argon2id`. this packages internally use the `@node-rs` package. To successfully deploy on AWS Lambda, this packages need to be excluded from the esbuild bundling process, similar to how `sharp` and `pg-native` are handled.

If the following Pull Request is merged, it may cause a conflict: sst/ion#549. If the above PR and current PR are merged, we can achieve a successful deployment.

Related library https://github.com/napi-rs/node-rs

<img width="1391" alt="image" src="https://github.com/sst/ion/assets/41789633/7cb5cf92-77fe-4791-ab93-4af1c725f6ba">

  
  
Closed sst/sst#4527 