### PR TITLE
fix(node): add __filename polyfill

### DIFF
--- a/pkg/js/js.go
+++ b/pkg/js/js.go
@@ -31,6 +31,7 @@ func Build(input EvalOptions) (esbuild.BuildResult, error) {
 import { createRequire as topLevelCreateRequire } from 'module';
 const require = topLevelCreateRequire(import.meta.url);
 import { fileURLToPath as topLevelFileUrlToPath, URL as topLevelURL } from "url"
+const __filename = topLevelFileUrlToPath(import.meta.url)
 const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))
 ` + input.Banner,
 		},

--- a/pkg/platform/src/runtime/node.ts
+++ b/pkg/platform/src/runtime/node.ts
@@ -82,6 +82,7 @@ export async function build(
               `import { createRequire as topLevelCreateRequire } from 'module';`,
               `const require = topLevelCreateRequire(import.meta.url);`,
               `import { fileURLToPath as topLevelFileUrlToPath, URL as topLevelURL } from "url"`,
+              `const __filename = topLevelFileUrlToPath(import.meta.url)`,
               `const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))`,
               `globalThis.$SST_LINKS = ${JSON.stringify(links)};`,
               nodejs.banner || "",

--- a/pkg/runtime/node.go
+++ b/pkg/runtime/node.go
@@ -156,6 +156,7 @@ func (r *NodeRuntime) Build(ctx context.Context, input *BuildInput) (*BuildOutpu
 				`import { createRequire as topLevelCreateRequire } from 'module';`,
 				`const require = topLevelCreateRequire(import.meta.url);`,
 				`import { fileURLToPath as topLevelFileUrlToPath, URL as topLevelURL } from "url"`,
+				`const __filename = topLevelFileUrlToPath(import.meta.url)`,
 				`const __dirname = topLevelFileUrlToPath(new topLevelURL(".", import.meta.url))`,
 				properties.Banner,
 			}, "\n"),


### PR DESCRIPTION
to get support for typescript emitDecoratorMetadata, the need to use typescript (or swc) from esbuild was needed.

but when I tried to transpileModule from esbuild plugin, it is run from within the eval***.mjs file, wich is ESM and typescript did not like that and needs __filename.

related to sst/sst#4645