### PR TITLE
fix(docs): incorrect CORS attribute names

### DIFF
--- a/pkg/platform/src/components/aws/function.ts
+++ b/pkg/platform/src/components/aws/function.ts
@@ -474,7 +474,7 @@ export interface FunctionArgs {
    *   url: {
    *     authorization: "iam",
    *     cors: {
-   *       allowedOrigins: ['https://example.com']
+   *       allowOrigins: ['https://example.com']
    *     }
    *   }
    * }
@@ -513,8 +513,8 @@ export interface FunctionArgs {
          * {
          *   url: {
          *     cors: {
-         *       allowedMethods: ["GET", "POST"],
-         *       allowedOrigins: ["https://example.com"]
+         *       allowMethods: ["GET", "POST"],
+         *       allowOrigins: ["https://example.com"]
          *     }
          *   }
          * }


### PR DESCRIPTION
Documentation on page:
https://ion.sst.dev/docs/component/aws/function/#url-cors
Corrected three instances where attribute name was 'allowed' instead of 'allow'
e.g. 'allowedOrigins' => 'allowOrigins'