### PR TITLE
Fix: Missing Cloudflare Queue in components

### DIFF
--- a/pkg/platform/src/components/component.ts
+++ b/pkg/platform/src/components/component.ts
@@ -153,6 +153,7 @@ export class Component extends ComponentResource {
             case "cloudflare:index/d1Database:D1Database":
             case "cloudflare:index/r2Bucket:R2Bucket":
             case "cloudflare:index/workerScript:WorkerScript":
+            case "cloudflare:index/queue:Queue":
               overrides = {
                 name: prefixName(64, args.name).toLowerCase(),
               };


### PR DESCRIPTION
This fixes a bug where Queue was not possible to deploy. 

Building the CLI with this fixed the issue. 