### PR TITLE
Next on cloudflare

### DIFF
--- a/pkg/platform/functions/cf-ssr-site-router-worker/index.ts
+++ b/pkg/platform/functions/cf-ssr-site-router-worker/index.ts
@@ -2,13 +2,22 @@ declare var caches: any;
 declare var SST_ASSET_MANIFEST: Record<string, string>;
 declare var SST_ROUTES: { regex: string; origin: "assets" | "server" }[];
 
-import { Buffer } from 'node:buffer';
-
 export interface Env {
   ASSETS: any;
   SERVER: any;
   ASSETS_PREFIX?: string;
 }
+
+function base64Decode (str: string) {
+  str = atob(str);
+  const
+    length = str.length,
+    buf = new ArrayBuffer(length),
+    bufView = new Uint8Array(buf);
+  for (var i = 0; i < length; i++) { bufView[i] = str.charCodeAt(i) }
+  return buf
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
 
@@ -17,6 +26,7 @@ export default {
 
     const url = new URL(request.url);
     const pathname = url.pathname.replace(/^\//, "");
+    const assetsPathname = getAssetsPathname(pathname);
 
     // Return from cache if available
     let cachedResponse = await lookupCache();
@@ -30,9 +40,8 @@ export default {
     }
     // Fetch from assets origin
     else if (route?.origin === "assets") {
-      const updPathname = getAssetsPathname(pathname);
-      const object = await env.ASSETS.getWithMetadata(updPathname);
-
+      
+      const object = await env.ASSETS.getWithMetadata(assetsPathname);
       if (object.value) return await respond(200, object);
     }
 
@@ -60,13 +69,13 @@ export default {
     async function respond(status: number, object: any) {
       // build response
       const headers = new Headers();
-      const updPathname = getAssetsPathname(pathname);
-      if (SST_ASSET_MANIFEST[updPathname]) {
-        headers.set("etag", SST_ASSET_MANIFEST[updPathname]);
+      if (SST_ASSET_MANIFEST[assetsPathname]) {
+        headers.set("etag", SST_ASSET_MANIFEST[assetsPathname]);
         headers.set("content-type", object.metadata.contentType);
         headers.set("cache-control", object.metadata.cacheControl);
       }
-      const decoded = Buffer.from(object.value, "base64").toString("utf-8");
+      
+      const decoded = base64Decode(object.value);
       const response = new Response(decoded, {
         status,
         headers,

--- a/pkg/platform/src/components/aws/ssr-site.ts
+++ b/pkg/platform/src/components/aws/ssr-site.ts
@@ -25,7 +25,7 @@ import { VisibleError } from "../error.js";
 import { Cron } from "./cron.js";
 import { OriginAccessIdentity } from "./providers/origin-access-identity.js";
 import { BaseSiteFileOptions } from "../base/base-site.js";
-import { BaseSsrSiteArgs } from "../base/base-ssr-site.js";
+import { BaseSsrSiteArgs, getContentType } from "../base/base-ssr-site.js";
 
 type CloudFrontFunctionConfig = { injections: string[] };
 type EdgeFunctionConfig = { function: Unwrap<FunctionArgs> };
@@ -341,50 +341,6 @@ export function createServersAndDistribution(
           { parent, ignoreChanges: $dev ? ["*"] : undefined },
         );
       });
-    }
-
-    function getContentType(filename: string, textEncoding: string) {
-      const ext = filename.endsWith(".well-known/site-association-json")
-        ? ".json"
-        : path.extname(filename);
-      const extensions = {
-        [".txt"]: { mime: "text/plain", isText: true },
-        [".htm"]: { mime: "text/html", isText: true },
-        [".html"]: { mime: "text/html", isText: true },
-        [".xhtml"]: { mime: "application/xhtml+xml", isText: true },
-        [".css"]: { mime: "text/css", isText: true },
-        [".js"]: { mime: "text/javascript", isText: true },
-        [".mjs"]: { mime: "text/javascript", isText: true },
-        [".apng"]: { mime: "image/apng", isText: false },
-        [".avif"]: { mime: "image/avif", isText: false },
-        [".gif"]: { mime: "image/gif", isText: false },
-        [".jpeg"]: { mime: "image/jpeg", isText: false },
-        [".jpg"]: { mime: "image/jpeg", isText: false },
-        [".png"]: { mime: "image/png", isText: false },
-        [".svg"]: { mime: "image/svg+xml", isText: true },
-        [".bmp"]: { mime: "image/bmp", isText: false },
-        [".tiff"]: { mime: "image/tiff", isText: false },
-        [".webp"]: { mime: "image/webp", isText: false },
-        [".ico"]: { mime: "image/vnd.microsoft.icon", isText: false },
-        [".eot"]: { mime: "application/vnd.ms-fontobject", isText: false },
-        [".ttf"]: { mime: "font/ttf", isText: false },
-        [".otf"]: { mime: "font/otf", isText: false },
-        [".woff"]: { mime: "font/woff", isText: false },
-        [".woff2"]: { mime: "font/woff2", isText: false },
-        [".json"]: { mime: "application/json", isText: true },
-        [".jsonld"]: { mime: "application/ld+json", isText: true },
-        [".xml"]: { mime: "application/xml", isText: true },
-        [".pdf"]: { mime: "application/pdf", isText: false },
-        [".zip"]: { mime: "application/zip", isText: false },
-        [".wasm"]: { mime: "application/wasm", isText: false },
-      };
-      const extensionData = extensions[ext as keyof typeof extensions];
-      const mime = extensionData?.mime ?? "application/octet-stream";
-      const charset =
-        extensionData?.isText && textEncoding !== "none"
-          ? `;charset=${textEncoding}`
-          : "";
-      return `${mime}${charset}`;
     }
 
     function createCloudFrontFunctions() {

--- a/pkg/platform/src/components/base/base-next.ts
+++ b/pkg/platform/src/components/base/base-next.ts
@@ -1,0 +1,198 @@
+import path from "node:path";
+import { VisibleError } from "../error";
+import fs from "node:fs";
+import { Input, Output, all } from "@pulumi/pulumi";
+
+export const DEFAULT_OPEN_NEXT_VERSION = "3.0.5";
+export const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = ["x-open-next-cache-key"];
+
+export type BaseFunction = {
+  handler: string;
+  bundle: string;
+};
+
+export type OpenNextFunctionOrigin = {
+  type: "function";
+  streaming?: boolean;
+  wrapper: string;
+  converter: string;
+} & BaseFunction;
+
+export type OpenNextServerFunctionOrigin = OpenNextFunctionOrigin & {
+  queue: string;
+  incrementalCache: string;
+  tagCache: string;
+};
+
+export type OpenNextImageOptimizationOrigin = OpenNextFunctionOrigin & {
+  imageLoader: string;
+};
+
+export type OpenNextS3Origin = {
+  type: "s3";
+  originPath: string;
+  copy: {
+    from: string;
+    to: string;
+    cached: boolean;
+    versionedSubDir?: string;
+  }[];
+};
+
+export interface OpenNextOutput {
+  edgeFunctions: {
+    [key: string]: BaseFunction;
+  } & {
+    middleware?: BaseFunction & { pathResolver: string };
+  };
+  origins: {
+    s3: OpenNextS3Origin;
+    default: OpenNextServerFunctionOrigin;
+    imageOptimizer: OpenNextImageOptimizationOrigin;
+  } & {
+    [key: string]: OpenNextServerFunctionOrigin | OpenNextS3Origin;
+  };
+  behaviors: {
+    pattern: string;
+    origin?: string;
+    edgeFunction?: string;
+  }[];
+  additionalProps?: {
+    disableIncrementalCache?: boolean;
+    disableTagCache?: boolean;
+    initializationFunction?: BaseFunction;
+    warmer?: BaseFunction;
+    revalidationFunction?: BaseFunction;
+  };
+}
+
+export function loadOpenNextOutput(outputPath: Output<string>) {
+  return outputPath.apply((outputPath) => {
+    const openNextOutputPath = path.join(
+      outputPath,
+      ".open-next",
+      "open-next.output.json",
+    );
+    if (!fs.existsSync(openNextOutputPath)) {
+      throw new VisibleError(
+        `Failed to load open-next.output.json from "${openNextOutputPath}".`,
+      );
+    }
+    const content = fs.readFileSync(openNextOutputPath).toString();
+    const json = JSON.parse(content) as OpenNextOutput;
+    // Currently open-next.output.json's initializationFunction value
+    // is wrong, it is set to ".open-next/initialization-function"
+    if (json.additionalProps?.initializationFunction) {
+      json.additionalProps.initializationFunction = {
+        handler: "index.handler",
+        bundle: ".open-next/dynamodb-provider",
+      };
+    }
+    return json;
+  });
+}
+
+export function loadOpenNextOutputPlaceholder(outputPath: Output<string>) {
+  // Configure origins and behaviors based on the Next.js app from quick start
+  return outputPath.apply((outputPath) => ({
+    edgeFunctions: {},
+    origins: {
+      s3: {
+        type: "s3",
+        originPath: "_assets",
+        // do not upload anything
+        copy: [],
+      },
+      imageOptimizer: {
+        type: "function",
+        handler: "index.handler",
+        bundle: path.join(
+          outputPath,
+          ".open-next/image-optimization-function",
+        ),
+        streaming: false,
+      },
+      default: {
+        type: "function",
+        handler: "index.handler",
+        bundle: path.join(
+          outputPath,
+          ".open-next/server-functions/default",
+        ),
+        streaming: false,
+      },
+    },
+    behaviors: [
+      { pattern: "_next/image*", origin: "imageOptimizer" },
+      { pattern: "_next/data/*", origin: "default" },
+      { pattern: "*", origin: "default" },
+      { pattern: "BUILD_ID", origin: "s3" },
+      { pattern: "_next/*", origin: "s3" },
+      { pattern: "favicon.ico", origin: "s3" },
+      { pattern: "next.svg", origin: "s3" },
+      { pattern: "vercel.svg", origin: "s3" },
+    ],
+    additionalProps: {
+      // skip creating revalidation queue
+      disableIncrementalCache: true,
+      // skip creating revalidation table
+      disableTagCache: true,
+    },
+  }));
+}
+
+export function loadBuildId(outputPath: Output<string>, name: string) {
+  return outputPath.apply((outputPath) => {
+    if ($dev) return "mock-build-id";
+
+    try {
+      return fs
+        .readFileSync(path.join(outputPath, ".next/BUILD_ID"))
+        .toString();
+    } catch (e) {
+      console.error(e);
+      throw new VisibleError(
+        `Failed to read build id from ".next/BUILD_ID" for the "${name}" site.`,
+      );
+    }
+  });
+}
+
+export function loadPrerenderManifest(outputPath: Output<string>) {
+  return outputPath.apply((outputPath) => {
+    if ($dev) return { version: 0, routes: {} };
+
+    try {
+      const content = fs
+        .readFileSync(
+          path.join(outputPath, ".next/prerender-manifest.json"),
+        )
+        .toString();
+      return JSON.parse(content) as {
+        version: number;
+        routes: Record<string, unknown>;
+      };
+    } catch (e) {
+      console.debug("Failed to load prerender-manifest.json", e);
+    }
+  });
+}
+
+export interface BaseNextArgs {
+  buildCommand?: string;
+  openNextVersion?: string;
+}
+
+export function normalizeBuildCommand(buildCommand?: Input<string>, openNextVersion?: Input<string>) {
+  return all([buildCommand, openNextVersion]).apply(
+    ([buildCommand, openNextVersion]) =>
+      buildCommand ??
+      [
+        "OPEN_NEXT_DEBUG=true",
+        "npx",
+        "--yes",
+        `open-next@${openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION}`,
+        "build",
+      ].join(" "),
+  );
+}

--- a/pkg/platform/src/components/base/base-next.ts
+++ b/pkg/platform/src/components/base/base-next.ts
@@ -3,7 +3,7 @@ import { VisibleError } from "../error";
 import fs from "node:fs";
 import { Input, Output, all } from "@pulumi/pulumi";
 
-export const DEFAULT_OPEN_NEXT_VERSION = "3.0.5";
+export const DEFAULT_OPEN_NEXT_VERSION = "3.0.6";
 export const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = ["x-open-next-cache-key"];
 
 export type BaseFunction = {

--- a/pkg/platform/src/components/base/base-ssr-site.ts
+++ b/pkg/platform/src/components/base/base-ssr-site.ts
@@ -200,3 +200,47 @@ export function buildApp(
     }
   });
 }
+
+export function getContentType(filename: string, textEncoding: string) {
+  const ext = filename.endsWith(".well-known/site-association-json")
+    ? ".json"
+    : path.extname(filename);
+  const extensions = {
+    [".txt"]: { mime: "text/plain", isText: true },
+    [".htm"]: { mime: "text/html", isText: true },
+    [".html"]: { mime: "text/html", isText: true },
+    [".xhtml"]: { mime: "application/xhtml+xml", isText: true },
+    [".css"]: { mime: "text/css", isText: true },
+    [".js"]: { mime: "text/javascript", isText: true },
+    [".mjs"]: { mime: "text/javascript", isText: true },
+    [".apng"]: { mime: "image/apng", isText: false },
+    [".avif"]: { mime: "image/avif", isText: false },
+    [".gif"]: { mime: "image/gif", isText: false },
+    [".jpeg"]: { mime: "image/jpeg", isText: false },
+    [".jpg"]: { mime: "image/jpeg", isText: false },
+    [".png"]: { mime: "image/png", isText: false },
+    [".svg"]: { mime: "image/svg+xml", isText: true },
+    [".bmp"]: { mime: "image/bmp", isText: false },
+    [".tiff"]: { mime: "image/tiff", isText: false },
+    [".webp"]: { mime: "image/webp", isText: false },
+    [".ico"]: { mime: "image/vnd.microsoft.icon", isText: false },
+    [".eot"]: { mime: "application/vnd.ms-fontobject", isText: false },
+    [".ttf"]: { mime: "font/ttf", isText: false },
+    [".otf"]: { mime: "font/otf", isText: false },
+    [".woff"]: { mime: "font/woff", isText: false },
+    [".woff2"]: { mime: "font/woff2", isText: false },
+    [".json"]: { mime: "application/json", isText: true },
+    [".jsonld"]: { mime: "application/ld+json", isText: true },
+    [".xml"]: { mime: "application/xml", isText: true },
+    [".pdf"]: { mime: "application/pdf", isText: false },
+    [".zip"]: { mime: "application/zip", isText: false },
+    [".wasm"]: { mime: "application/wasm", isText: false },
+  };
+  const extensionData = extensions[ext as keyof typeof extensions];
+  const mime = extensionData?.mime ?? "application/octet-stream";
+  const charset =
+    extensionData?.isText && textEncoding !== "none"
+      ? `;charset=${textEncoding}`
+      : "";
+  return `${mime}${charset}`;
+}

--- a/pkg/platform/src/components/cloudflare/index.ts
+++ b/pkg/platform/src/components/cloudflare/index.ts
@@ -8,3 +8,4 @@ export * from "./worker";
 export * from "./account-id";
 export * from "./auth";
 export * from "./queue";
+export * from "./next"

--- a/pkg/platform/src/components/cloudflare/next.ts
+++ b/pkg/platform/src/components/cloudflare/next.ts
@@ -627,7 +627,10 @@ export class NextJs extends Component implements Link.Linkable {
           return {
             handler: path.join(outputPath, openNextOutput.edgeFunctions.middleware!.bundle, 'handler.mjs'),
             environment: {
-              OPEN_NEXT_ORIGIN: jsonStringify(openNextOrigin)
+              OPEN_NEXT_ORIGIN: jsonStringify(openNextOrigin),
+              // When the domain is not set, we disable the cache.
+              // Haven't found a proper way to invalidate the cache when the domain is not set.
+              DISABLE_CACHE: args.domain ? "false" : "true",
             },
             build: {
               esbuild: {

--- a/pkg/platform/src/components/cloudflare/next.ts
+++ b/pkg/platform/src/components/cloudflare/next.ts
@@ -1,0 +1,749 @@
+import fs from "fs";
+import path from "path";
+import { pathToRegexp } from "path-to-regexp";
+import { ComponentResourceOptions, Output, all, jsonStringify, output } from "@pulumi/pulumi";
+import {
+  SsrSiteArgs,
+  createKvStorage,
+  createRouter,
+  prepare,
+  validatePlan,
+} from "./ssr-site.js";
+import { Component } from "../component.js";
+import { Hint } from "../hint.js";
+import { Link } from "../link.js";
+import { Kv } from "./kv.js";
+import { buildApp, getContentType } from "../base/base-ssr-site.js";
+import { Worker, WorkerArgs } from "./worker.js";
+import { Plugin } from "esbuild";
+
+// Aws specific imports
+import {Bucket} from '../aws/bucket.js'
+import {Function} from '../aws/function.js'
+import { 
+  OpenNextServerFunctionOrigin,
+  loadOpenNextOutput, 
+  loadOpenNextOutputPlaceholder, 
+  loadPrerenderManifest,
+  normalizeBuildCommand
+} from "../base/base-next.js";
+import { Queue } from "../aws/queue.js";
+import * as aws from "@pulumi/aws";
+import { BucketFile, BucketFiles } from "../aws/providers/bucket-files.js";
+import { BaseSiteFileOptions } from "../base/base-site.js";
+import { globSync } from "glob";
+import crypto from "crypto";
+
+
+export interface NextArgs extends SsrSiteArgs {
+  /**
+   * Configure how the Next app assets are uploaded to S3.
+   *
+   * By default, this is set to the following. Read more about these options below.
+   * ```js
+   * {
+   *   assets: {
+   *     textEncoding: "utf-8",
+   *     versionedFilesCacheHeader: "public,max-age=31536000,immutable",
+   *     nonVersionedFilesCacheHeader: "public,max-age=0,s-maxage=86400,stale-while-revalidate=8640"
+   *   }
+   * }
+   * ```
+   */
+  assets?: SsrSiteArgs["assets"];
+  /**
+   * The command used internally to build your Remix app.
+   *
+   * @default `"npx open-next build"`
+   *
+   * @example
+   *
+   * If you want to use a different build command.
+   * ```js
+   * {
+   *   buildCommand: "npm run custom-build"
+   * }
+   * ```
+   */
+  buildCommand?: SsrSiteArgs["buildCommand"];
+  /**
+   * Set a custom domain for your Remix app. Supports domains hosted either on
+   * [Route 53](https://aws.amazon.com/route53/) or outside AWS.
+   *
+   * :::tip
+   * You can also migrate an externally hosted domain to Amazon Route 53 by
+   * [following this guide](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+   * :::
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   domain: "domain.com"
+   * }
+   * ```
+   *
+   * Specify a `www.` version of the custom domain.
+   *
+   * ```js
+   * {
+   *   domain: {
+   *     name: "domain.com",
+   *     redirects: ["www.domain.com"]
+   *   }
+   * }
+   * ```
+   */
+  domain?: SsrSiteArgs["domain"];
+  /**
+   * Set [environment variables](https://remix.run/docs/en/main/guides/envvars) in your Remix app. These are made available:
+   *
+   * 1. In `remix build`, they are loaded into `process.env`.
+   * 2. Locally while running `sst dev remix dev`.
+   *
+   * :::tip
+   * You can also `link` resources to your Remix app and access them in a type-safe way with the [SDK](/docs/reference/sdk/). We recommend linking since it's more secure.
+   * :::
+   *
+   * @example
+   * ```js
+   * {
+   *   environment: {
+   *     API_URL: api.url,
+   *     STRIPE_PUBLISHABLE_KEY: "pk_test_123"
+   *   }
+   * }
+   * ```
+   */
+  environment?: SsrSiteArgs["environment"];
+  /**
+   * [Link resources](/docs/linking/) to your Remix app. This will:
+   *
+   * 1. Grant the permissions needed to access the resources.
+   * 2. Allow you to access it in your site using the [SDK](/docs/reference/sdk/).
+   *
+   * @example
+   *
+   * Takes a list of resources to link to the function.
+   *
+   * ```js
+   * {
+   *   link: [bucket, stripeKey]
+   * }
+   * ```
+   */
+  link?: SsrSiteArgs["link"];
+  /**
+   * Path to the directory where your Remix app is located.  This path is relative to your `sst.config.ts`.
+   *
+   * By default it assumes your Remix app is in the root of your SST app.
+   * @default `"."`
+   *
+   * @example
+   *
+   * If your Remix app is in a package in your monorepo.
+   *
+   * ```js
+   * {
+   *   path: "packages/web"
+   * }
+   * ```
+   */
+  path?: SsrSiteArgs["path"];
+}
+
+/**
+ * The `Remix` component lets you deploy a [Remix](https://remix.run) app to AWS.
+ *
+ * @example
+ *
+ * #### Minimal example
+ *
+ * Deploy a Remix app that's in the project root.
+ *
+ * ```js
+ * new sst.aws.Remix("MyWeb");
+ * ```
+ *
+ * #### Change the path
+ *
+ * Deploys the Remix app in the `my-remix-app/` directory.
+ *
+ * ```js {2}
+ * new sst.aws.Remix("MyWeb", {
+ *   path: "my-remix-app/"
+ * });
+ * ```
+ *
+ * #### Add a custom domain
+ *
+ * Set a custom domain for your Remix app.
+ *
+ * ```js {2}
+ * new sst.aws.Remix("MyWeb", {
+ *   domain: "my-app.com"
+ * });
+ * ```
+ *
+ * #### Redirect www to apex domain
+ *
+ * Redirect `www.my-app.com` to `my-app.com`.
+ *
+ * ```js {4}
+ * new sst.aws.Remix("MyWeb", {
+ *   domain: {
+ *     name: "my-app.com",
+ *     redirects: ["www.my-app.com"]
+ *   }
+ * });
+ * ```
+ *
+ * #### Link resources
+ *
+ * [Link resources](/docs/linking/) to your Remix app. This will grant permissions
+ * to the resources and allow you to access it in your app.
+ *
+ * ```ts {4}
+ * const bucket = new sst.aws.Bucket("MyBucket");
+ *
+ * new sst.aws.Remix("MyWeb", {
+ *   link: [bucket]
+ * });
+ * ```
+ *
+ * You can use the [SDK](/docs/reference/sdk/) to access the linked resources
+ * in your Remix app.
+ *
+ * ```ts title="app/root.tsx"
+ * import { Resource } from "sst";
+ *
+ * console.log(Resource.MyBucket.name);
+ * ```
+ */
+export class NextJs extends Component implements Link.Linkable {
+  private assets: Kv;
+  private router: Output<Worker>;
+  private middleware: Output<Worker>;
+  private servers: Output<Record<string, Function>>;
+  private cacheBucket: Bucket;
+
+  constructor(
+    name: string,
+    args: NextArgs = {},
+    opts: ComponentResourceOptions = {},
+  ) {
+    super(__pulumiType, name, args, opts);
+
+    const parent = this;
+    const buildCommand = normalizeBuildCommand(args.buildCommand);
+    const region = normalizeRegion();
+    const { sitePath } = prepare(args);
+    const storage = createKvStorage(parent, name, args);
+    const bucket = new Bucket(`${name}S3Cache`, {}, { parent });
+    const outputPath = buildApp(name, args, sitePath, buildCommand);
+    
+    const { openNextOutput, prerenderManifest } = loadBuildOutput();
+    const revalidationQueue = createRevalidationQueue();
+    const revalidationTable = createRevalidationTable();
+    createRevalidationTableSeeder();
+    const servers = createServersLambda();
+    const middlewareArgs = createMiddleware();
+    const plan = buildPlan();
+    uploadCache();
+    const { router, server: middleware } = createRouter(
+      parent,
+      name,
+      args,
+      outputPath,
+      storage,
+      plan,
+    );
+
+
+    this.assets = storage;
+    this.router = router;
+    this.middleware = middleware;
+    this.servers = servers;
+    this.cacheBucket = bucket;
+    if (!$dev) {
+      Hint.register(this.urn, this.url as Output<string>);
+    }
+    this.registerOutputs({
+      _metadata: {
+        mode: $dev ? "placeholder" : "deployed",
+        path: sitePath,
+        url: this.url,
+      },
+    });
+
+
+    function loadBuildOutput() {
+      const openNextOutput = ($dev ? loadOpenNextOutputPlaceholder(outputPath) : loadOpenNextOutput(outputPath))as ReturnType<typeof loadOpenNextOutput>
+      return {
+        openNextOutput,
+        prerenderManifest: loadPrerenderManifest(outputPath),
+      };
+    }
+
+    function normalizeRegion() {
+      return aws.getRegionOutput(undefined, { provider: opts?.provider }).name;
+    }
+
+    function createRevalidationQueue() {
+      return all([outputPath, openNextOutput]).apply(
+        ([outputPath, openNextOutput]) => {
+          if (openNextOutput.additionalProps?.disableIncrementalCache) return;
+
+          const revalidationFunction =
+            openNextOutput.additionalProps?.revalidationFunction;
+          if (!revalidationFunction) return;
+
+          const queue = new Queue(
+            `${name}RevalidationEvents`,
+            {
+              fifo: true,
+              transform: {
+                queue: (args) => {
+                  args.receiveWaitTimeSeconds = 20;
+                },
+              },
+            },
+            { parent },
+          );
+          queue.subscribe(
+            {
+              description: `${name} ISR revalidator`,
+              handler: revalidationFunction.handler,
+              bundle: path.join(outputPath, revalidationFunction.bundle),
+              runtime: "nodejs20.x",
+              timeout: "30 seconds",
+              permissions: [
+                {
+                  actions: [
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:DeleteMessage",
+                    "sqs:GetQueueAttributes",
+                    "sqs:GetQueueUrl",
+                    "sqs:ReceiveMessage",
+                  ],
+                  resources: [queue.arn],
+                },
+              ],
+              live: false,
+              _ignoreCodeChanges: $dev,
+              _skipMetadata: true,
+            },
+            {
+              transform: {
+                eventSourceMapping: (args) => {
+                  args.batchSize = 5;
+                },
+              },
+            },
+            { parent },
+          );
+          return queue;
+        },
+      );
+    }
+
+    function createRevalidationTable() {
+      return openNextOutput.apply((openNextOutput) => {
+        if (openNextOutput.additionalProps?.disableTagCache) return;
+
+        return new aws.dynamodb.Table(
+          `${name}RevalidationTable`,
+          {
+            attributes: [
+              { name: "tag", type: "S" },
+              { name: "path", type: "S" },
+              { name: "revalidatedAt", type: "N" },
+            ],
+            hashKey: "tag",
+            rangeKey: "path",
+            pointInTimeRecovery: {
+              enabled: true,
+            },
+            billingMode: "PAY_PER_REQUEST",
+            globalSecondaryIndexes: [
+              {
+                name: "revalidate",
+                hashKey: "path",
+                rangeKey: "revalidatedAt",
+                projectionType: "ALL",
+              },
+            ],
+          },
+          { parent },
+        );
+      });
+    }
+
+    function createRevalidationTableSeeder() {
+      return all([
+        revalidationTable,
+        outputPath,
+        openNextOutput,
+        prerenderManifest,
+      ]).apply(
+        ([
+          revalidationTable,
+          outputPath,
+          openNextOutput,
+          prerenderManifest,
+        ]) => {
+          if (openNextOutput.additionalProps?.disableTagCache) return;
+          if (!openNextOutput.additionalProps?.initializationFunction) return;
+
+          // Provision 128MB of memory for every 4,000 prerendered routes,
+          // 1GB per 40,000, up to 10GB. This tends to use ~70% of the memory
+          // provisioned when testing.
+          const prerenderedRouteCount = Object.keys(
+            prerenderManifest?.routes ?? {},
+          ).length;
+          const seedFn = new Function(
+            `${name}RevalidationSeeder`,
+            {
+              description: `${name} ISR revalidation data seeder`,
+              handler:
+                openNextOutput.additionalProps.initializationFunction.handler,
+              bundle: path.join(
+                outputPath,
+                openNextOutput.additionalProps.initializationFunction.bundle,
+              ),
+              runtime: "nodejs20.x",
+              timeout: "900 seconds",
+              memory: `${Math.min(
+                10240,
+                Math.max(128, Math.ceil(prerenderedRouteCount / 4000) * 128),
+              )} MB`,
+              permissions: [
+                {
+                  actions: [
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:DescribeTable",
+                  ],
+                  resources: [revalidationTable!.arn],
+                },
+              ],
+              environment: {
+                CACHE_DYNAMO_TABLE: revalidationTable!.name,
+              },
+              live: false,
+              _ignoreCodeChanges: $dev,
+              _skipMetadata: true,
+            },
+            { parent },
+          );
+          new aws.lambda.Invocation(
+            `${name}RevalidationSeed`,
+            {
+              functionName: seedFn.nodes.function.name,
+              triggers: {
+                version: Date.now().toString(),
+              },
+              input: JSON.stringify({
+                RequestType: "Create",
+              }),
+            },
+            { parent, ignoreChanges: $dev ? ["*"] : undefined },
+          );
+        },
+      );
+    }
+
+    function buildPlan() {
+      return all([outputPath, openNextOutput, middlewareArgs]).apply(
+        ([outputPath, openNextOutput, middlewareArgs]) => {
+          return validatePlan({
+            server: middlewareArgs,
+            assets: {
+              assetsPrefix: '_assets',
+              copy: openNextOutput.origins.s3.copy.filter(copy => copy.to !== "_cache"),
+            },
+            routes: [
+              {
+                regex: pathToRegexp("_next/data(.*)").source,
+                origin: "server" as const,
+              },
+              {
+                regex: pathToRegexp("_next/image(.*)").source,
+                origin: "server" as const,
+              },
+              ...openNextOutput.behaviors.filter(b => b.origin === 's3').map(b => ({
+                regex: pathToRegexp(b.pattern.replace('*', '(.*)')).source,
+                origin: "assets" as const,
+              })),
+              {
+                regex: pathToRegexp("(.*)").source,
+                origin: "server" as const,
+              },
+            ],
+          });
+        },
+      );
+    }
+
+    function createServersLambda() : Output<Record<string, Function>> {
+      return all([
+        outputPath, 
+        openNextOutput,
+        [bucket.arn, bucket.name],
+        revalidationQueue.apply((q) => ({ url: q?.url, arn: q?.arn })),
+        revalidationTable.apply((t) => ({ name: t?.name, arn: t?.arn })),
+        region
+      ]).apply(
+        ([
+          outputPath, 
+          openNextOutput,
+          [bucketArn, bucketName],
+          { url: revalidationQueueUrl, arn: revalidationQueueArn },
+          { name: revalidationTableName, arn: revalidationTableArn },
+          region
+        ]) => {
+          const serversOutput = Object.entries(openNextOutput.origins).filter(([_, origin]) => origin.type === "function") as [string, OpenNextServerFunctionOrigin][];
+          const defaultFunctionProps = {
+            runtime: "nodejs20.x" as const,
+            environment: {
+              CACHE_BUCKET_NAME: bucketName,
+              CACHE_BUCKET_KEY_PREFIX: "_cache",
+              CACHE_BUCKET_REGION: region,
+              ...(revalidationQueueUrl && {
+                REVALIDATION_QUEUE_URL: revalidationQueueUrl,
+                REVALIDATION_QUEUE_REGION: region,
+              }),
+              ...(revalidationTableName && {
+                CACHE_DYNAMO_TABLE: revalidationTableName,
+              }),
+            },
+            permissions: [
+              // access to the cache data
+              {
+                actions: ["s3:GetObject", "s3:PutObject"],
+                resources: [`${bucketArn}/*`],
+              },
+              ...(revalidationQueueArn
+                ? [
+                    {
+                      actions: [
+                        "sqs:SendMessage",
+                        "sqs:GetQueueAttributes",
+                        "sqs:GetQueueUrl",
+                      ],
+                      resources: [revalidationQueueArn],
+                    },
+                  ]
+                : []),
+              ...(revalidationTableArn
+                ? [
+                    {
+                      actions: [
+                        "dynamodb:BatchGetItem",
+                        "dynamodb:GetRecords",
+                        "dynamodb:GetShardIterator",
+                        "dynamodb:Query",
+                        "dynamodb:GetItem",
+                        "dynamodb:Scan",
+                        "dynamodb:ConditionCheckItem",
+                        "dynamodb:BatchWriteItem",
+                        "dynamodb:PutItem",
+                        "dynamodb:UpdateItem",
+                        "dynamodb:DeleteItem",
+                        "dynamodb:DescribeTable",
+                      ],
+                      resources: [
+                        revalidationTableArn,
+                        `${revalidationTableArn}/*`,
+                      ],
+                    },
+                  ]
+                : []),
+            ],
+          };
+          return serversOutput.reduce((acc, [_name, origin]) => {
+            acc[_name] = new Function(
+              `${name}${_name}Server`,
+              {
+                description: `${_name} server function`,
+                handler: origin.handler,
+                bundle: path.join(outputPath, origin.bundle),
+                streaming: origin.streaming,
+                url: true,
+                live: false,
+                ...defaultFunctionProps,
+              },
+              { parent },
+            );
+            return acc;
+          }, {} as Record<string, Function>);
+        })
+    }
+
+    function createMiddleware() : Output<WorkerArgs> {
+      return all([outputPath, openNextOutput]).apply(
+        ([outputPath, openNextOutput]) => {
+
+          const openNextOrigin = servers.apply((origins) : Record<string, {
+            host: Output<string>,
+            protocol: string,
+          }> => {
+            const r = Object.entries(origins).map(([key, value]) => {
+              return [key, {
+                  host: value.url.apply(url => new URL(url).hostname),
+                  protocol: "https",
+                }
+                ]
+            })
+            return Object.fromEntries(r)
+          })
+
+          const nodeBuiltInModulesPlugin: Plugin = {
+            name: "node:built-in:modules",
+            setup(build) {
+              build.onResolve({ filter: /^(util|stream)$/ }, ({ kind, path }) => {
+                // this plugin converts `require("node:*")` calls, those are the only ones that
+                // need updating (esm imports to "node:*" are totally valid), so here we tag with the
+                // node-buffer namespace only imports that are require calls
+                return kind === "require-call"
+                  ? { path, namespace: "node-built-in-modules" }
+                  : undefined;
+              });
+    
+              // we convert the imports we tagged with the node-built-in-modules namespace so that instead of `require("node:*")`
+              // they import from `export * from "node:*";`
+              build.onLoad(
+                { filter: /.*/, namespace: "node-built-in-modules" },
+                ({ path }) => {
+                  return {
+                    contents: `export * from 'node:${path}'`,
+                    loader: "js",
+                  };
+                },
+              );
+            },
+          };
+
+          return {
+            handler: path.join(outputPath, openNextOutput.edgeFunctions.middleware!.bundle, 'handler.mjs'),
+            environment: {
+              OPEN_NEXT_ORIGIN: jsonStringify(openNextOrigin)
+            },
+            build: {
+              esbuild: {
+                resolveExtensions: [".tsx",".ts",".jsx",".js",".mjs",".css",".json"],
+                external: ['./KVCache'],
+                plugins: [nodeBuiltInModulesPlugin],
+              }
+            }
+          };
+        },
+      );
+    
+    }
+
+    function uploadCache() {
+      return all([openNextOutput, outputPath]).apply(async ([openNextOutput, outputPath]) => {
+
+        const bucketFiles: BucketFile[] = [];
+
+        const copy = openNextOutput.origins.s3.copy.find((copy) => copy.to === "_cache");
+        if(!copy) return;
+
+        // Build fileOptions
+        const fileOptions: BaseSiteFileOptions[] = [
+          // unversioned files
+          {
+            files: "**",
+            cacheControl: 'private, no-cache, no-store, must-revalidate',
+          },
+        ];
+
+        // Upload files based on fileOptions
+        const filesUploaded: string[] = [];
+        for (const fileOption of fileOptions.reverse()) {
+          const files = globSync(fileOption.files, {
+            cwd: path.resolve(outputPath, copy.from),
+            nodir: true,
+            dot: true,
+            ignore: fileOption.ignore,
+          }).filter((file) => !filesUploaded.includes(file));
+
+          bucketFiles.push(
+            ...(await Promise.all(
+              files.map(async (file) => {
+                const source = path.resolve(outputPath, copy.from, file);
+                const content = await fs.promises.readFile(source);
+                const hash = crypto
+                  .createHash("sha256")
+                  .update(content)
+                  .digest("hex");
+                return {
+                  source,
+                  key: path.posix.join(copy.to, file),
+                  hash,
+                  cacheControl: fileOption.cacheControl,
+                  contentType: getContentType(file, "UTF-8"),
+                };
+              }),
+            )),
+          );
+          filesUploaded.push(...files);
+            
+        }
+
+        return new BucketFiles(
+          `${name}AssetFiles`,
+          {
+            bucketName: bucket.name,
+            files: bucketFiles,
+          },
+          { parent, ignoreChanges: $dev ? ["*"] : undefined },
+        );
+      });
+    }
+
+  }
+
+  /**
+   * The URL of the Remix app.
+   *
+   * If the `domain` is set, this is the URL with the custom domain.
+   * Otherwise, it's the autogenerated CloudFront URL.
+   */
+  public get url() {
+    return this.router.url;
+  }
+
+  /**
+   * The underlying [resources](/docs/components/#nodes) this component creates.
+   */
+  public get nodes() {
+    return {
+      /**
+       * The cloudfare worker that routes requests to the correct origin.
+       */
+      middleware: this.middleware,
+      /**
+       * The serverless functions that serve the Next app.
+       */
+      servers: this.servers,
+      /**
+       * The Amazon S3 Bucket that stores the assets.
+       */
+      assets: this.assets,
+    };
+  }
+
+  /** @internal */
+  public getSSTLink() {
+    return {
+      properties: {
+        url: this.url,
+      },
+    };
+  }
+}
+const __pulumiType = "sst:cloudflare:Next";
+// @ts-expect-error
+NextJs.__pulumiType = __pulumiType;

--- a/pkg/platform/src/components/cloudflare/ssr-site.ts
+++ b/pkg/platform/src/components/cloudflare/ssr-site.ts
@@ -7,7 +7,7 @@ import { Input } from "../input.js";
 import { transform, type Transform } from "../component.js";
 import { VisibleError } from "../error.js";
 import { BaseSiteFileOptions } from "../base/base-site.js";
-import { BaseSsrSiteArgs } from "../base/base-ssr-site.js";
+import { BaseSsrSiteArgs, getContentType } from "../base/base-ssr-site.js";
 import { Kv, KvArgs } from "./kv.js";
 import { Worker, WorkerArgs } from "./worker.js";
 import { KvData } from "./providers/kv-data.js";
@@ -69,7 +69,7 @@ export function createRouter(
     const assetManifest = generateAssetManifest();
     const kvData = uploadAssets();
     const server = createServerWorker();
-    const router = createRouterWorker();
+    const router = createRouterWorker(plan.assets.assetsPrefix);
 
     return { server, router };
 
@@ -165,50 +165,6 @@ export function createRouter(
       );
     }
 
-    function getContentType(filename: string, textEncoding: string) {
-      const ext = filename.endsWith(".well-known/site-association-json")
-        ? ".json"
-        : path.extname(filename);
-      const extensions = {
-        [".txt"]: { mime: "text/plain", isText: true },
-        [".htm"]: { mime: "text/html", isText: true },
-        [".html"]: { mime: "text/html", isText: true },
-        [".xhtml"]: { mime: "application/xhtml+xml", isText: true },
-        [".css"]: { mime: "text/css", isText: true },
-        [".js"]: { mime: "text/javascript", isText: true },
-        [".mjs"]: { mime: "text/javascript", isText: true },
-        [".apng"]: { mime: "image/apng", isText: false },
-        [".avif"]: { mime: "image/avif", isText: false },
-        [".gif"]: { mime: "image/gif", isText: false },
-        [".jpeg"]: { mime: "image/jpeg", isText: false },
-        [".jpg"]: { mime: "image/jpeg", isText: false },
-        [".png"]: { mime: "image/png", isText: false },
-        [".svg"]: { mime: "image/svg+xml", isText: true },
-        [".bmp"]: { mime: "image/bmp", isText: false },
-        [".tiff"]: { mime: "image/tiff", isText: false },
-        [".webp"]: { mime: "image/webp", isText: false },
-        [".ico"]: { mime: "image/vnd.microsoft.icon", isText: false },
-        [".eot"]: { mime: "application/vnd.ms-fontobject", isText: false },
-        [".ttf"]: { mime: "font/ttf", isText: false },
-        [".otf"]: { mime: "font/otf", isText: false },
-        [".woff"]: { mime: "font/woff", isText: false },
-        [".woff2"]: { mime: "font/woff2", isText: false },
-        [".json"]: { mime: "application/json", isText: true },
-        [".jsonld"]: { mime: "application/ld+json", isText: true },
-        [".xml"]: { mime: "application/xml", isText: true },
-        [".pdf"]: { mime: "application/pdf", isText: false },
-        [".zip"]: { mime: "application/zip", isText: false },
-        [".wasm"]: { mime: "application/wasm", isText: false },
-      };
-      const extensionData = extensions[ext as keyof typeof extensions];
-      const mime = extensionData?.mime ?? "application/octet-stream";
-      const charset =
-        extensionData?.isText && textEncoding !== "none"
-          ? `;charset=${textEncoding}`
-          : "";
-      return `${mime}${charset}`;
-    }
-
     function createServerWorker() {
       return new Worker(
         `${name}Server`,
@@ -229,7 +185,7 @@ export function createRouter(
       );
     }
 
-    function createRouterWorker() {
+    function createRouterWorker(assetsPrefix?:string) {
       return new Worker(
         `${name}Router`,
         {
@@ -251,6 +207,9 @@ export function createRouter(
               },
             })),
           },
+          environment: assetsPrefix ? {
+            ASSETS_PREFIX: assetsPrefix,
+          } : {},
           transform: {
             worker: (workerArgs) => {
               workerArgs.kvNamespaceBindings = [
@@ -278,6 +237,7 @@ export function createRouter(
 export function validatePlan(input: {
   server: Unwrap<WorkerArgs>;
   assets: {
+    assetsPrefix?: string;
     copy: {
       from: string;
       to: string;


### PR DESCRIPTION
This PR add partial support for Next on cloudflare.
For now only the middleware and the assets can be deployed on cloudflare, the rest needs to be on aws.

It requires this https://github.com/sst/open-next/pull/449 to be merged to work perfectly ( Likely in 3.0.6 )

The assets are deployed on KV and all the cache related stuff are still in aws.

One big issues i've found while testing was that it seems impossible to invalidate cache when using only worker url. To fix this the cache is disabled by default when no domains is set.

Below is an `open-next.config.ts` file that works (and is necessary) to deploy : 
```ts
import type {OpenNextConfig} from 'open-next/types/open-next.js'

const config  = {
  default: {
    override: {
      // This is not necessary, but useful to test streaming
      wrapper: 'aws-lambda-streaming',
    }
  }, 

  middleware: {
    external: true,
    override: {
      wrapper: 'cloudflare',
      converter: 'edge'
    }
  },
  imageOptimization: {
    // @ts-ignore
    loader: 'host',
    arch: 'x64'
  },
  // buildCommand: 'echo "Skipping build..."'
} satisfies OpenNextConfig

export default config
```