### PR TITLE
fix inconsistency with AWS being top level and cloudflare being nested

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -12,18 +12,24 @@ const sidebar = [
   {
     label: "Get Started",
     items: [
-      { label: "API", link: "/docs/start/aws/api/" },
-      { label: "Solid", link: "/docs/start/aws/solid/" },
-      { label: "tRPC", link: "/docs/start/aws/trpc/" },
-      { label: "Hono", link: "/docs/start/aws/hono/" },
-      { label: "Astro", link: "/docs/start/aws/astro/" },
-      { label: "Email", link: "/docs/start/aws/email/" },
-      { label: "Remix", link: "/docs/start/aws/remix/" },
-      { label: "Svelte", link: "/docs/start/aws/svelte/" },
-      { label: "Drizzle", link: "/docs/start/aws/drizzle/" },
-      { label: "Next.js", link: "/docs/start/aws/nextjs/" },
-      { label: "Realtime", link: "/docs/start/aws/realtime/" },
-      { label: "Container", link: "/docs/start/aws/container/" },
+      {
+        label: "AWS",
+        items: [
+          { label: "API", link: "/docs/start/aws/api/" },
+          { label: "Solid", link: "/docs/start/aws/solid/" },
+          { label: "tRPC", link: "/docs/start/aws/trpc/" },
+          { label: "Hono", link: "/docs/start/aws/hono/" },
+          { label: "Astro", link: "/docs/start/aws/astro/" },
+          { label: "Email", link: "/docs/start/aws/email/" },
+          { label: "Remix", link: "/docs/start/aws/remix/" },
+          { label: "Svelte", link: "/docs/start/aws/svelte/" },
+          { label: "Drizzle", link: "/docs/start/aws/drizzle/" },
+          { label: "Next.js", link: "/docs/start/aws/nextjs/" },
+          { label: "Realtime", link: "/docs/start/aws/realtime/" },
+          { label: "Container", link: "/docs/start/aws/container/" },
+        ],
+      },
+
       {
         label: "Cloudflare",
         items: [


### PR DESCRIPTION
Just fixes how `/docs/start/aws/[slug]/` were top level in the sidebar but `/docs/start/cloudflare/[slug]/` were nested under a second tier, small thing that was bothering me when looking through, should also make it cleaner as more providers get added.

## Old
<img width="344" alt="image" src="https://github.com/sst/ion/assets/147033096/f393e11c-86e8-4372-8e91-d5d835fd3d8e">

## New
<img width="344" alt="image" src="https://github.com/sst/ion/assets/147033096/e93871ef-7888-4302-9aa7-c20ee3c1b47e">
