### PR TITLE
adds findRecord to cloudflare only

### DIFF
--- a/pkg/platform/src/components/aws/dns.ts
+++ b/pkg/platform/src/components/aws/dns.ts
@@ -71,7 +71,14 @@ export function dns(args: DnsArgs = {}) {
     provider: "aws",
     createRecord,
     createAliasRecords,
+    findRecord
   } satisfies Dns;
+
+  function findRecord() {
+    throw new Error(
+      `Current version of the AWS adapter does not support finding records.`
+    );
+  }
 
   /**
    * Creates a DNS record in the hosted zone.

--- a/pkg/platform/src/components/cloudflare/dns.ts
+++ b/pkg/platform/src/components/cloudflare/dns.ts
@@ -70,7 +70,43 @@ export function dns(args: DnsArgs = {}) {
   return {
     provider: "cloudflare",
     createRecord,
+    findRecord,
   } satisfies Dns;
+
+  async function findRecord(
+    namePrefix: string,
+    record: Record,
+    opts: ComponentResourceOptions,
+  ) {
+    return output(record).apply((record) => {
+      const nameSuffix = sanitizeToPascalCase(record.name);
+      const zoneId = lookupZone();
+      const dnsRecord = findRecord();
+      return dnsRecord;
+
+      function lookupZone() {
+        if (args.zone) return args.zone;
+        return new ZoneLookup(
+          `${namePrefix}${record.type}ZoneLookup${nameSuffix}`,
+          {
+            accountId: sst.cloudflare.DEFAULT_ACCOUNT_ID,
+            domain: output(record.name).apply((name) =>
+              name.replace(/\.$/, ""),
+            ),
+          },
+          opts,
+        ).id;
+      }
+
+      function findRecord() {
+        return cloudflare.getRecord({
+          zoneId: zoneId.toString(),
+          type: record.type,
+          hostname: record.name,
+        })
+      }
+    });
+  }
 
   function createRecord(
     namePrefix: string,

--- a/pkg/platform/src/components/dns.ts
+++ b/pkg/platform/src/components/dns.ts
@@ -6,6 +6,7 @@
 
 import { ComponentResourceOptions, Output, Resource } from "@pulumi/pulumi";
 import { Input } from "./input";
+import { GetRecordResult } from "@pulumi/cloudflare/getRecord";
 
 export interface Record {
   /**
@@ -43,25 +44,36 @@ type CreateRecord = (
   opts: ComponentResourceOptions,
 ) => Output<Resource>;
 
+type FindRecord = (
+    namePrefix: string,
+    record: Record,
+    opts: ComponentResourceOptions,
+) => Promise<Output<GetRecordResult>>;
+
 type CreateAliasRecord = (
   namePrefix: string,
   record: AliasRecord,
   opts: ComponentResourceOptions,
 ) => Output<Resource>[];
 
+type UnSupportedFindRecord = () => void;
+
 type AwsDns = {
   provider: "aws";
   createRecord: CreateRecord;
   createAliasRecords: CreateAliasRecord;
+  findRecord: UnSupportedFindRecord;
 };
 
 type CloudflareDns = {
   provider: "cloudflare";
   createRecord: CreateRecord;
+  findRecord: FindRecord;
 };
 type VercelDns = {
   provider: "vercel";
   createRecord: CreateRecord;
+  findRecord: UnSupportedFindRecord;
 };
 
 export type Dns = AwsDns | CloudflareDns | VercelDns;

--- a/pkg/platform/src/components/vercel/dns.ts
+++ b/pkg/platform/src/components/vercel/dns.ts
@@ -70,6 +70,7 @@ export function dns(args: DnsArgs) {
   return {
     provider: "vercel",
     createRecord,
+    findRecord
   } satisfies Dns;
 
   function useCAARecord(namePrefix: string, opts: ComponentResourceOptions) {
@@ -87,6 +88,12 @@ export function dns(args: DnsArgs) {
       );
     }
     return caaRecord;
+  }
+
+  function findRecord() {
+    throw new Error(
+      `Currentr version of the Vercel adapter does not support finding records.`
+    );
   }
 
   function createRecord(

--- a/pkg/platform/src/components/vercel/dns.ts
+++ b/pkg/platform/src/components/vercel/dns.ts
@@ -92,7 +92,7 @@ export function dns(args: DnsArgs) {
 
   function findRecord() {
     throw new Error(
-      `Currentr version of the Vercel adapter does not support finding records.`
+      `Current version of the Vercel adapter does not support finding records.`
     );
   }
 


### PR DESCRIPTION
This PR adds `findRecord` function to Cloudflare, currently they're the only provider that supports the feature.


**Use case:** 
Re-running ion would error if a record already exists, it helps if we can check to avoid this error.