### PR TITLE
Allow for configuring shared Server Cache Policy ID

### DIFF
--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -373,6 +373,18 @@ export interface NextjsArgs extends SsrSiteArgs {
    * ```
    */
   vpc?: SsrSiteArgs["vpc"];
+  /**
+   * Set a shared server cache policy id. Prevents creating new cache policies
+   * that cause hitting AWS' 20 custom policies hard limit.
+   *
+   * @example
+   * ```js
+   * {
+   *   cdnServerCachePolicyId: "2a8001c4-41ef-4459-9576-d2ecf2532da8"
+   * }
+   * ```  
+   */
+  cdnServerCachePolicyId?: Input<string>;
 }
 
 /**

--- a/pkg/platform/src/components/aws/ssr-site.ts
+++ b/pkg/platform/src/components/aws/ssr-site.ts
@@ -100,6 +100,7 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
       }
   >;
   vpc?: FunctionArgs["vpc"];
+  cdnServerCachePolicyId?: Input<string>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
    * resources.
@@ -642,7 +643,7 @@ function handler(event) {
           ],
           cachedMethods: ["GET", "HEAD"],
           compress: true,
-          cachePolicyId: useServerBehaviorCachePolicy().id,
+          cachePolicyId: args.cdnServerCachePolicyId ?? useServerBehaviorCachePolicy().id,
           // CloudFront's Managed-AllViewerExceptHostHeader policy
           originRequestPolicyId: "b689b0a8-53d0-40ab-baf2-68738e2966ac",
           functionAssociations: cfFunction


### PR DESCRIPTION
### Addresses this issue: https://github.com/sst/sst/issues/4667

AWS has a hard limit of 20 custom Cache Policies. My use case heavily depends on this. I've have been using [SST's CDK Server Cache Policy's configuration](https://docs.sst.dev/constructs/NextjsSite#reusing-cloudfront-cache-policies). Yet, in SST Ion, this is the _last_ piece that's blocking me from migrating. 

P.S.: I just rediscovered [this PR](https://github.com/sst/ion/pull/593) late which does the same thing.