### PR TITLE
Update Next example

### DIFF
--- a/examples/aws-nextjs/next.config.mjs
+++ b/examples/aws-nextjs/next.config.mjs
@@ -1,4 +1,14 @@
+import * as path from "node:path";
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  webpack: (config, { nextRuntime }) => {
+    if (nextRuntime === "edge") {
+      // Ensure sst uses Node's process module and not a popular shim package when compiling middleware.
+      config.resolve.alias.process = path.resolve("node:process");
+    }
+    return config;
+  },
+};
 
 export default nextConfig;

--- a/sdk/js/src/resource.ts
+++ b/sdk/js/src/resource.ts
@@ -1,4 +1,4 @@
-const env = process.env;
+import { env } from "process";
 
 export interface Resource {
   App: {

--- a/sdk/js/src/resource.ts
+++ b/sdk/js/src/resource.ts
@@ -1,4 +1,4 @@
-import { env } from "process";
+const env = process.env;
 
 export interface Resource {
   App: {


### PR DESCRIPTION
Adds the webpack config override to get around an issue when a dependency depends on https://www.npmjs.com/package/process, causing the middleware compilation to load the browser shim.