### PR TITLE
Secure Function Urls with IAM Auth

### DIFF
--- a/pkg/platform/src/components/aws/function.ts
+++ b/pkg/platform/src/components/aws/function.ts
@@ -480,7 +480,7 @@ export interface FunctionArgs {
    * ```js
    * {
    *   url: {
-   *     authorization: "iam",
+   *     authorization: "AWS_IAM",
    *     cors: {
    *       allowOrigins: ['https://example.com']
    *     }
@@ -493,17 +493,17 @@ export interface FunctionArgs {
     | {
         /**
          * The authorization used for the function URL. Supports [IAM authorization](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
-         * @default `"none"`
+         * @default `"NONE"`
          * @example
          * ```js
          * {
          *   url: {
-         *     authorization: "iam"
+         *     authorization: "AWS_IAM"
          *   }
          * }
          * ```
          */
-        authorization?: Input<"none" | "iam">;
+        authorization?: Input<"NONE" | "AWS_IAM">;
         /**
          * Customize the CORS (Cross-origin resource sharing) settings for the function URL.
          * @default `true`
@@ -1049,7 +1049,7 @@ export class Function extends Component implements Link.Linkable, AWSLinkable {
         }
 
         // normalize authorization
-        const defaultAuthorization = "none" as const;
+        const defaultAuthorization = "NONE" as const;
         const authorization = url.authorization ?? defaultAuthorization;
 
         // normalize cors

--- a/pkg/platform/src/components/aws/nextjs.ts
+++ b/pkg/platform/src/components/aws/nextjs.ts
@@ -323,6 +323,17 @@ export interface NextjsArgs extends SsrSiteArgs {
    */
   openNextVersion?: Input<string>;
   /**
+   * Ensure function urls use IAM Auth instead of being public access.
+   * @default `false`
+   * @example
+   * ```js
+   * {
+   *   enableServerUrlIamAuth: true,
+   * }
+   * ```
+   */
+  enableServerUrlIamAuth?: Input<boolean>;
+  /**
    * Configure the Lambda function used for image optimization.
    * @default `{memory: "1024 MB"}`
    */
@@ -753,6 +764,7 @@ export class Nextjs extends Component implements Link.Linkable {
         buildId,
         openNextOutput,
         args?.imageOptimization,
+        args?.enableServerUrlIamAuth,
         [bucket.arn, bucket.name],
         revalidationQueue.apply((q) => ({ url: q?.url, arn: q?.arn })),
         revalidationTable.apply((t) => ({ name: t?.name, arn: t?.arn })),
@@ -762,6 +774,7 @@ export class Nextjs extends Component implements Link.Linkable {
           buildId,
           openNextOutput,
           imageOptimization,
+          enableServerUrlIamAuth,
           [bucketArn, bucketName],
           { url: revalidationQueueUrl, arn: revalidationQueueArn },
           { name: revalidationTableName, arn: revalidationTableArn },
@@ -885,6 +898,9 @@ export class Nextjs extends Component implements Link.Linkable {
                               : {}),
                           },
                           memory: imageOptimization?.memory ?? "1536 MB",
+                          url: {
+                            authorization: enableServerUrlIamAuth ? 'AWS_IAM' : 'NONE'
+                          }
                         },
                       },
                     },
@@ -900,6 +916,9 @@ export class Nextjs extends Component implements Link.Linkable {
                         bundle: path.join(outputPath, value.bundle),
                         handler: value.handler,
                         streaming: value.streaming,
+                        url: {
+                          authorization: enableServerUrlIamAuth ? 'AWS_IAM' : 'NONE'
+                        },
                         ...defaultFunctionProps,
                       },
                     },


### PR DESCRIPTION
PR for issue: https://github.com/sst/sst/issues/4483

The Nextjs construct makes lambdas that are publicly available at a function url. We need the option to lock those down with IAM.

Note, here is the equivalent functionality in SST 2: https://docs.sst.dev/constructs/NextjsSite#regionalenableserverurliamauth