### PR TITLE
[docs] fix missing comma in example

### DIFF
--- a/pkg/platform/src/config.ts
+++ b/pkg/platform/src/config.ts
@@ -568,7 +568,7 @@ export interface Config {
      *       if (event.type === "pushed" && event.branch === "main") {
      *         return {
      *           stage: "production",
-     *           runner: { engine: "codebuild", compute: "large" },
+     *           runner: { engine: "codebuild", compute: "large" }
      *         };
      *       }
      *     }

--- a/pkg/platform/src/config.ts
+++ b/pkg/platform/src/config.ts
@@ -400,7 +400,7 @@ export interface BranchEvent {
   branch: string;
   /**
    * Info about the commit in the event. This might look like:
-   * 
+   *
    * ```js
    * {
    *   id: "b7e7c4c559e0e5b4bc6f8d98e0e5e5e5e5e5e5e5",
@@ -486,7 +486,7 @@ export interface PullRequestEvent {
   head: string;
   /**
    * Info about the commit in the event. This might look like:
-   * 
+   *
    * ```js
    * {
    *   id: "b7e7c4c559e0e5b4bc6f8d98e0e5e5e5e5e5e5e5",
@@ -567,8 +567,8 @@ export interface Config {
      *     target(event) {
      *       if (event.type === "pushed" && event.branch === "main") {
      *         return {
-     *           stage: "production"
-     *           runner: { engine: "codebuild", compute: "large" };
+     *           stage: "production",
+     *           runner: { engine: "codebuild", compute: "large" },
      *         };
      *       }
      *     }


### PR DESCRIPTION
https://ion.sst.dev/docs/console/#autodeploy

```
console: {
  autodeploy: {
    target(event) {
      if (event.type === "pushed" && event.branch === "main") {
        return {
          stage: "production"
          runner: { engine: "codebuild", compute: "large" };
        };
      }
    }
  }
}
```

to

```
console: {
  autodeploy: {
    target(event) {
      if (event.type === "pushed" && event.branch === "main") {
        return {
          stage: "production",
          runner: { engine: "codebuild", compute: "large" },
        };
      }
    }
  }
}
```