### PR TITLE
fix: set correct assetsVersionedSubDir for remix

### DIFF
--- a/platform/src/components/aws/remix.ts
+++ b/platform/src/components/aws/remix.ts
@@ -435,7 +435,7 @@ export class Remix extends Component implements Link.Linkable {
           const assetsPath = isUsingVite
             ? path.join("build", "client")
             : "public";
-          const assetsVersionedSubDir = isUsingVite ? undefined : "build";
+          const assetsVersionedSubDir = isUsingVite ? "assets" : "build";
 
           return {
             assetsPath,

--- a/platform/src/components/cloudflare/remix.ts
+++ b/platform/src/components/cloudflare/remix.ts
@@ -267,7 +267,7 @@ export class Remix extends Component implements Link.Linkable {
           const assetsPath = isUsingVite
             ? path.join("build", "client")
             : "public";
-          const assetsVersionedSubDir = isUsingVite ? undefined : "build";
+          const assetsVersionedSubDir = isUsingVite ? "assets" : "build";
 
           return {
             assetsPath,


### PR DESCRIPTION
Fixes: sst/sst#4437 

Static assets for a remix deployment are served with the `nonVersionedFilesCacheHeader` and don't benefit from efficient caching.

<img width="1582" alt="Bildschirmfoto 2024-07-04 um 17 07 27" src="https://github.com/sst/ion/assets/778624/068c6f42-45fa-4361-8ac0-426c5be2d275">

This seems to happen because the `assetsVersionedSubDir` isn't set correctly for vite builds of remix. Vite puts the static assets in `build/client/assets`.

<img width="257" alt="Bildschirmfoto 2024-07-04 um 17 03 14" src="https://github.com/sst/ion/assets/778624/056040b7-e9bf-4bf9-a761-43809fbd7ec2">

This PR sets the directory correctly (I think) which should result in the correct headers being applied (I hope). Literally only been playing with SST for 30 minutes. No idea if that's the right place. Wouldn't be surprised if I'm showing severe skill issues here :D 