### PR TITLE
Update goreleaser

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -36,7 +36,7 @@ jobs:
       - run: bun i --frozen-lockfile
       - run: git reset --hard
 
-      - uses: goreleaser/goreleaser-action@v4
+      - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: sst
 before:
   hooks:


### PR DESCRIPTION
Fixes the following:

```
❯ goreleaser build
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```

```
❯ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    2.1.0
GitCommit:     2a1bcaca534197ba122e76812d842aedf61930fe
GitTreeState:  clean
BuildDate:     2024-07-13T17:21:33
BuiltBy:       homebrew
GoVersion:     go1.22.5
Compiler:      gc
ModuleSum:     unknown
Platform:      darwin/arm64
```

Updating should work fine:

```
❯ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

See https://goreleaser.com/deprecations/