### PR TITLE
sst.aws.postgres: expose node field on PostgresRef

### DIFF
--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -356,8 +356,8 @@ export class Postgres extends Component implements Link.Linkable, AWSLinkable {
   public static get(
     name: string,
     args: {
-      cluster: rds.GetClusterOutputArgs;
-      instance?: rds.GetInstanceOutputArgs;
+      cluster: rds.GetClusterArgs;
+      instance?: rds.GetInstanceArgs;
     },
     opts?: ComponentResourceOptions,
   ) {

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -355,7 +355,10 @@ export class Postgres extends Component implements Link.Linkable, AWSLinkable {
   /** @internal */
   public static get(
     name: string,
-    args: rds.GetClusterArgs,
+    args: {
+      cluster: rds.GetClusterOutputArgs;
+      instance?: rds.GetInstanceOutputArgs;
+    },
     opts?: ComponentResourceOptions,
   ) {
     return new PostgresRef(name, args, opts);
@@ -395,16 +398,21 @@ function getSSTAWSPermissions(
 
 class PostgresRef extends Component implements Link.Linkable, AWSLinkable {
   private cluster: Output<rds.GetClusterResult>;
-  private instance: Output<rds.GetInstanceResult>;
+  private instance?: Output<rds.GetInstanceResult>;
 
   constructor(
     name: string,
-    args: rds.GetClusterOutputArgs,
+    args: {
+      cluster: rds.GetClusterOutputArgs;
+      instance?: rds.GetInstanceOutputArgs;
+    },
     opts?: ComponentResourceOptions,
   ) {
     super(__pulumiType + "Ref", name, args, opts);
-    this.cluster = rds.getClusterOutput(args, opts);
-    this.instance = rds.getInstanceOutput(args, opts);
+    this.cluster = rds.getClusterOutput(args.cluster, opts);
+    this.instance = args.instance
+      ? rds.getInstanceOutput(args.instance, opts)
+      : undefined;
   }
   /**
    * The ARN of the RDS Cluster.

--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -395,6 +395,7 @@ function getSSTAWSPermissions(
 
 class PostgresRef extends Component implements Link.Linkable, AWSLinkable {
   private cluster: Output<rds.GetClusterResult>;
+  private instance: Output<rds.GetInstanceResult>;
 
   constructor(
     name: string,
@@ -403,6 +404,7 @@ class PostgresRef extends Component implements Link.Linkable, AWSLinkable {
   ) {
     super(__pulumiType + "Ref", name, args, opts);
     this.cluster = rds.getClusterOutput(args, opts);
+    this.instance = rds.getInstanceOutput(args, opts);
   }
   /**
    * The ARN of the RDS Cluster.
@@ -425,6 +427,13 @@ class PostgresRef extends Component implements Link.Linkable, AWSLinkable {
     return this.cluster.databaseName;
   }
 
+  public get nodes() {
+    return {
+      cluster: this.cluster,
+      instance: this.instance,
+    };
+  }
+
   /** @internal */
   public getSSTLink() {
     return getSSTLink(this.cluster);
@@ -432,22 +441,7 @@ class PostgresRef extends Component implements Link.Linkable, AWSLinkable {
 
   /** @internal */
   public getSSTAWSPermissions() {
-    return [
-      {
-        actions: ["secretsmanager:GetSecretValue"],
-        resources: [this.cluster.masterUserSecrets[0].secretArn],
-      },
-      {
-        actions: [
-          "rds-data:BatchExecuteStatement",
-          "rds-data:BeginTransaction",
-          "rds-data:CommitTransaction",
-          "rds-data:ExecuteStatement",
-          "rds-data:RollbackTransaction",
-        ],
-        resources: [this.cluster.arn],
-      },
-    ];
+    return getSSTAWSPermissions(this.cluster);
   }
 }
 


### PR DESCRIPTION
Allows access to instance as well as cluster when `get`-ting an existing PostgresDB