### PR TITLE
fix: regional remix server sending multiple cookies

### DIFF
--- a/platform/functions/react-server/regional-server.mjs
+++ b/platform/functions/react-server/regional-server.mjs
@@ -113,6 +113,7 @@ const createApigHandler = (build) => {
         ...Object.fromEntries(response.headers.entries()),
         "Transfer-Encoding": "chunked",
       },
+      cookies: response.headers.getSetCookie(),
     };
     if (response.body) {
       const reader = response.body;

--- a/platform/functions/remix-server/regional-server.mjs
+++ b/platform/functions/remix-server/regional-server.mjs
@@ -113,6 +113,7 @@ const createApigHandler = (build) => {
         ...Object.fromEntries(response.headers.entries()),
         "Transfer-Encoding": "chunked",
       },
+      cookies: response.headers.getSetCookie(),
     };
 
     const writer = awslambda.HttpResponseStream.from(


### PR DESCRIPTION
This fixes sending multiple cookies in a response in a regional Remix function. The way it is now, only one `Set-Cookie` makes it into the response because the headers are a plain JS object with unique keys. AWS instead wants an array of `Set-Cookie` values on the `cookies` property in the response payload.

From their [docs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads):
```json
{
   "statusCode": 201,
    "headers": {
        "Content-Type": "application/json",
        "My-Custom-Header": "Custom Value"
    },
    "body": "{ \"message\": \"Hello, world!\" }",
    "cookies": [
        "Cookie_1=Value1; Expires=21 Oct 2021 07:48 GMT",
        "Cookie_2=Value2; Max-Age=78000"
    ],
    "isBase64Encoded": false
}
```