### PR TITLE
Fix typo in live.mdx

### DIFF
--- a/www/src/content/docs/docs/live.mdx
+++ b/www/src/content/docs/docs/live.mdx
@@ -20,7 +20,7 @@ This setup of running your functions locally and proxying the results back allow
 
 - Your changes are **reloaded in under 10ms**.
 - You can set **breakpoints to debug** your function in your favorite IDE.
-- Functions can be invoke remotely. For example, say `https://my-api.com/hello` is your API endpoint. Hitting that will run the local version of that function.
+- Functions can be invoked remotely. For example, say `https://my-api.com/hello` is your API endpoint. Hitting that will run the local version of that function.
   - This applies to more than just APIs. Any cron job or async event that gets invoked remotely will also run your local function.
   - It allows you to very easily debug and **test webhooks**, since you can just give the webhook your API endpoint.
   - Supports all function triggers, there's no need to mock an event.


### PR DESCRIPTION
Fixes small typo in https://ion.sst.dev/docs/live:  

<img width="932" alt="Screenshot 2024-07-18 at 8 36 15 AM" src="https://github.com/user-attachments/assets/8d8331e4-9a78-41f8-98b1-030555075f3a">

