### PR TITLE
fix: docs for autodeploy event types

### DIFF
--- a/platform/src/config.ts
+++ b/platform/src/config.ts
@@ -642,7 +642,11 @@ export interface Config {
      * console: {
      *   autodeploy: {
      *     target(event) {
-     *       if (event.type === "pushed" && event.branch === "main") {
+     *       if (
+     *         event.type === "branch" &&
+     *         event.branch === "main" &&
+     *         event.action === "pushed"
+     *        ) {
      *         return {
      *           stage: "production",
      *           runner: { engine: "codebuild", compute: "large" }
@@ -700,7 +704,7 @@ export interface Config {
        *
        * ```ts
        * target(event) {
-       *   if (event.type === "pushed" && event.branch === "main") {
+       *   if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
        *     return { stage: "production" };
        *   }
        * }
@@ -711,8 +715,8 @@ export interface Config {
        *
        * ```ts {2}
        * target(event) {
-       *   if (event.branch === "staging") return;
-       *   if (event.type === "pushed" && event.branch === "main") {
+       *   if (event.type === "branch" && event.branch === "staging") return;
+       *   if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
        *     return { stage: "production" };
        *   }
        * }
@@ -732,7 +736,7 @@ export interface Config {
        *
        * ```ts
        * target(event) {
-       *   if (event.type === "pushed" && event.branch === "main") {
+       *   if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
        *     return {
        *       stage: "production"
        *       runner: {

--- a/www/src/content/docs/docs/console.mdx
+++ b/www/src/content/docs/docs/console.mdx
@@ -447,7 +447,7 @@ For example, if you want git pushes to the `main` branch auto-deploy the `produc
 console: {
   autodeploy: {
     target(event) {
-      if (event.type === "pushed" && event.branch === "main") {
+      if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
         return {
           stage: "production",
           runner: { engine: "codebuild", compute: "large" }

--- a/www/src/content/docs/docs/reference/config.mdx
+++ b/www/src/content/docs/docs/reference/config.mdx
@@ -117,7 +117,7 @@ that'll be used to run the build.
 console: {
   autodeploy: {
     target(event) {
-      if (event.type === "pushed" && event.branch === "main") {
+      if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
         return {
           stage: "production",
           runner: { engine: "codebuild", compute: "large" }
@@ -189,7 +189,7 @@ For example, to auto-deploy to the `production` stage when you git push to the
 
 ```ts
 target(event) {
-  if (event.type === "pushed" && event.branch === "main") {
+  if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
     return { stage: "production" };
   }
 }
@@ -200,8 +200,8 @@ example, to skip any deploys to the `staging` stage.
 
 ```ts {2}
 target(event) {
-  if (event.branch === "staging") return;
-  if (event.type === "pushed" && event.branch === "main") {
+  if (event.type === "branch" && event.branch === "staging") return;
+  if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
     return { stage: "production" };
   }
 }
@@ -221,7 +221,7 @@ For example, to use a larger machine for the `production` stage.
 
 ```ts
 target(event) {
-  if (event.type === "pushed" && event.branch === "main") {
+  if (event.type === "branch" && event.branch === "main" && event.action === "pushed") {
     return {
       stage: "production"
       runner: {


### PR DESCRIPTION
Fixing the examples for autodeploy. `event.type === "pushed"` is not an option, it should be `event.action === "pushed`. 
`event.type === "pushed" && event.branch === "main"` will change to `event.type === "branch" && event.branch === "main" && event.action === "pushed"`