### PR TITLE
Write stack outputs to JSON file

### DIFF
--- a/pkg/project/stack.go
+++ b/pkg/project/stack.go
@@ -479,6 +479,11 @@ func (p *Project) Run(ctx context.Context, input *StackInput) error {
 			}
 		}
 
+		outputsFilePath := filepath.Join(p.PathWorkingDir(), "outputs.json")
+		outputsFile, _ := os.Create(outputsFilePath)
+		defer outputsFile.Close()
+		json.NewEncoder(outputsFile).Encode(complete.Outputs)
+
 		typesFileName := "sst-env.d.ts"
 		typesFilePath := filepath.Join(p.PathRoot(), typesFileName)
 		typesFile, _ := os.Create(typesFilePath)

--- a/www/src/content/docs/docs/reference/config.mdx
+++ b/www/src/content/docs/docs/reference/config.mdx
@@ -314,6 +314,10 @@ This will display the following in the CLI.
 ```bash frame=\"none\"
 bucket: bucket-jOaikGu4rla
 ```
+
+Additionally, all outputs are written to the `.sst/outputs.json` file in your
+project's root directory in JSON format, after every successful deployment
+of your resources.
 </Segment>
 
 ## App


### PR DESCRIPTION
Opening this PR to address a need I had for easily parseable stack outputs. While I understand that `sst shell` is the recommended way to reference resources, for non-linkable resources, I still found this helpful.

Tested by running `goreleaser build --clean --snapshot --skip validate` and using the resulting binary on my SST projects - I validated the `dev`, `refresh`, and `deploy` commands.

I also added a note to the config docs for discoverability.