### PR TITLE
Json unmarshal error - Update svelte-kit template preset.json

### DIFF
--- a/platform/templates/svelte-kit/preset.json
+++ b/platform/templates/svelte-kit/preset.json
@@ -23,7 +23,7 @@
       "properties": [
         "Next steps: update svelte.config.js",
         "",
-        "import adapter from \"svelte-kit-sst\";",
+        "import adapter from \"svelte-kit-sst\";"
       ]
     }
   ]


### PR DESCRIPTION
The comma in line 26 is causing "invalid character ']' looking for beginning of value" error when trying to set up sst@ion with svelte-kit.