### PR TITLE
Added directive for intellisense to find sst module in infra files

### DIFF
--- a/examples/aws-monorepo/infra/index.ts
+++ b/examples/aws-monorepo/infra/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="../.sst/platform/config.d.ts" />
 export * from "./api";
 export * from "./database";
 export * from "./frontend";


### PR DESCRIPTION
When using VSCode or similar IDE's with Intellisense, they have trouble finding `sst` inside the `infra` folder and there is no way to import `sst` as a module.

By placing `/// <reference path="../.sst/platform/config.d.ts" />` at the top of the `index.ts` in the `infra` folder, this allows intellisense find `sst` for those files.