### PR TITLE
perf: faster file system operations

### DIFF
--- a/platform/src/components/aws/astro.ts
+++ b/platform/src/components/aws/astro.ts
@@ -494,22 +494,13 @@ export class Astro extends Component implements Link.Linkable {
             ...fs
               .readdirSync(
                 path.join(outputPath, buildMeta.clientBuildOutputDir),
+                { withFileTypes: true },
               )
               .map(
                 (item) =>
                   ({
                     cacheType: "static",
-                    pattern: fs
-                      .statSync(
-                        path.join(
-                          outputPath,
-                          buildMeta.clientBuildOutputDir,
-                          item,
-                        ),
-                      )
-                      .isDirectory()
-                      ? `${item}/*`
-                      : item,
+                    pattern: item.isDirectory() ? `${item.name}/*` : item.name,
                     origin: "staticsServer",
                   }) as const,
               ),

--- a/platform/src/components/aws/nuxt.ts
+++ b/platform/src/components/aws/nuxt.ts
@@ -423,12 +423,10 @@ export class Nuxt extends Component implements Link.Linkable {
           assetsPath,
           // create 1 behaviour for each top level asset file/folder
           staticRoutes: fs
-            .readdirSync(path.join(outputPath, assetsPath))
-            .map((item) =>
-              fs.statSync(path.join(outputPath, assetsPath, item)).isDirectory()
-                ? `${item}/*`
-                : item,
-            ),
+            .readdirSync(path.join(outputPath, assetsPath), {
+              withFileTypes: true,
+            })
+            .map((item) => (item.isDirectory() ? `${item.name}/*` : item.name)),
         };
       });
     }

--- a/platform/src/components/aws/react.ts
+++ b/platform/src/components/aws/react.ts
@@ -444,12 +444,10 @@ export class React extends Component implements Link.Linkable {
             : undefined,
           // create 1 behaviour for each top level asset file/folder
           staticRoutes: fs
-            .readdirSync(path.join(outputPath, assetsPath))
-            .map((item) =>
-              fs.statSync(path.join(outputPath, assetsPath, item)).isDirectory()
-                ? `${item}/*`
-                : item,
-            ),
+            .readdirSync(path.join(outputPath, assetsPath), {
+              withFileTypes: true,
+            })
+            .map((item) => (item.isDirectory() ? `${item.name}/*` : item.name)),
         };
       });
     }

--- a/platform/src/components/aws/remix.ts
+++ b/platform/src/components/aws/remix.ts
@@ -456,13 +456,11 @@ export class Remix extends Component implements Link.Linkable {
             assetsVersionedSubDir,
             // create 1 behaviour for each top level asset file/folder
             staticRoutes: fs
-              .readdirSync(path.join(outputPath, assetsPath))
+              .readdirSync(path.join(outputPath, assetsPath), {
+                withFileTypes: true,
+              })
               .map((item) =>
-                fs
-                  .statSync(path.join(outputPath, assetsPath, item))
-                  .isDirectory()
-                  ? `${item}/*`
-                  : item,
+                item.isDirectory() ? `${item.name}/*` : item.name,
               ),
           };
         },

--- a/platform/src/components/aws/solid-start.ts
+++ b/platform/src/components/aws/solid-start.ts
@@ -433,12 +433,10 @@ export class SolidStart extends Component implements Link.Linkable {
           assetsPath,
           // create 1 behaviour for each top level asset file/folder
           staticRoutes: fs
-            .readdirSync(path.join(outputPath, assetsPath))
-            .map((item) =>
-              fs.statSync(path.join(outputPath, assetsPath, item)).isDirectory()
-                ? `${item}/*`
-                : item,
-            ),
+            .readdirSync(path.join(outputPath, assetsPath), {
+              withFileTypes: true,
+            })
+            .map((item) => (item.isDirectory() ? `${item.name}/*` : item.name)),
         };
       });
     }

--- a/platform/src/components/aws/svelte-kit.ts
+++ b/platform/src/components/aws/svelte-kit.ts
@@ -457,11 +457,13 @@ export class SvelteKit extends Component implements Link.Linkable {
           assetsVersionedSubDir: "_app",
           // create 1 behaviour for each top level asset file/folder
           staticRoutes: fs
-            .readdirSync(path.join(outputPath, assetsPath))
+            .readdirSync(path.join(outputPath, assetsPath), {
+              withFileTypes: true,
+            })
             .map((item) =>
-              fs.statSync(path.join(outputPath, assetsPath, item)).isDirectory()
-                ? `${basePath}${item}/*`
-                : `${basePath}${item}`,
+              item.isDirectory()
+                ? `${basePath}${item.name}/*`
+                : `${basePath}${item.name}`,
             ),
         };
       });

--- a/platform/src/components/cloudflare/remix.ts
+++ b/platform/src/components/cloudflare/remix.ts
@@ -275,13 +275,11 @@ export class Remix extends Component implements Link.Linkable {
             assetsVersionedSubDir,
             // create 1 behaviour for each top level asset file/folder
             staticRoutes: fs
-              .readdirSync(path.join(outputPath, assetsPath))
+              .readdirSync(path.join(outputPath, assetsPath), {
+                withFileTypes: true,
+              })
               .map((item) =>
-                fs
-                  .statSync(path.join(outputPath, assetsPath, item))
-                  .isDirectory()
-                  ? `${item}/(.*)`
-                  : item,
+                item.isDirectory() ? `${item.name}/(.*)` : item.name,
               ),
           };
         },

--- a/platform/src/util/fs.ts
+++ b/platform/src/util/fs.ts
@@ -15,13 +15,12 @@ export async function findBelow(dir: string, target: string) {
     const current = path.join(dir, target);
     if (await existsAsync(current)) return dir;
 
-    const files = await fs.readdir(dir);
+    const files = await fs.readdir(dir, { withFileTypes: true });
     for (const file of files) {
-      if (file === "node_modules") continue;
-      if (file === ".sst") continue;
-      const full = path.join(dir, file);
-      const stat = await fs.stat(full);
-      if (stat.isDirectory()) {
+      if (file.name === "node_modules") continue;
+      if (file.name === ".sst") continue;
+      if (file.isDirectory()) {
+        const full = path.join(dir, file.name);
         const result = await loop(full);
         if (result) return result;
       }


### PR DESCRIPTION
Fixes: sst/sst#4366 

Passing `withFileTypes: true` to `fs.readdir`/`fs.readdirSync` is orders of magnitudes faster than doing repeated `stat` calls in a loop.

```sh
❯ node fs-bench.js
565 FILES
withFileTypes: true: 0.092ms

❯ sudo purge

❯ node fs-bench.js
565 FILES
repeated fs.statSync: 8.331ms
```

This might be irrelevant in the grand scheme of things but since it also made the code easier I thought it would be worth it.