### PR TITLE
bug: Vector.QueryResponse type error

### DIFF
--- a/sdk/js/src/vector/index.ts
+++ b/sdk/js/src/vector/index.ts
@@ -169,13 +169,18 @@ export interface RemoveEvent {
 
 export interface QueryResponse {
   /**
-   * Metadata for the event that was provided when storing the vector.
+   * List of result objects matching the query.
    */
-  metadata: Record<string, any>;
-  /**
-   * The similarity score between the prompt and the queried vector.
-   */
-  score: number;
+  results: {
+    /**
+     * Metadata for the event that was provided when storing the vector.
+     */
+    metadata: Record<string, any>;
+    /**
+     * The similarity score between the prompt and the queried vector.
+     */
+    score: number;
+  }[];
 }
 
 export interface VectorClientResponse {

--- a/sdk/js/src/vector/index.ts
+++ b/sdk/js/src/vector/index.ts
@@ -169,7 +169,7 @@ export interface RemoveEvent {
 
 export interface QueryResponse {
   /**
-   * List of result objects matching the query.
+   * List of results matching the query.
    */
   results: {
     /**
@@ -250,11 +250,11 @@ export function VectorClient<
   T extends keyof {
     // @ts-expect-error
     [key in keyof Resource as "sst.aws.Vector" extends Resource[key]["type"]
-    ? string extends key
-    ? never
-    : key
-    : never]: Resource[key];
-  },
+      ? string extends key
+        ? never
+        : key
+      : never]: Resource[key];
+  }
 >(name: T): VectorClientResponse {
   return {
     put: async (event: PutEvent) => {


### PR DESCRIPTION
Fixes: https://github.com/sst/sst/issues/4358

## Fix
Update the `QueryResponse` type to match the implemented return type of `VectorClientResponse.query()`.

Likely want to derive the QueryResponse type from the implementation but this is sufficient.