### PR TITLE
fix crypto import

### DIFF
--- a/platform/src/components/aws/cdn.ts
+++ b/platform/src/components/aws/cdn.ts
@@ -14,6 +14,7 @@ import { Dns } from "../dns.js";
 import { dns as awsDns } from "./dns.js";
 import { cloudfront } from "@pulumi/aws";
 import { DistributionInvalidation } from "./providers/distribution-invalidation.js";
+import crypto from "crypto";
 
 export interface CdnDomainArgs {
   /**


### PR DESCRIPTION
attempt to fix https://github.com/sst/sst/issues/4357
```
Running program '/tmp/repo/.sst/platform/sst.config.1722392645972.mjs' failed with an unhandled exception:
ReferenceError: crypto is not defined
    at file:///tmp/repo/.sst/platform/src/components/aws/cdn.ts:404:16
    at /tmp/repo/.sst/platform/node_modules/@pulumi/output.ts:402:31
    at Generator.next (<anonymous>)
    at /tmp/repo/.sst/platform/node_modules/@pulumi/pulumi/output.js:21:71
    at new Promise (<anonymous>)
    at __awaiter (/tmp/repo/.sst/platform/node_modules/@pulumi/pulumi/output.js:17:12)
    at applyHelperAsync (/tmp/repo/.sst/platform/node_modules/@pulumi/pulumi/output.js:244:12)
    at /tmp/repo/.sst/platform/node_modules/@pulumi/output.ts:316:13
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```