### PR TITLE
Fix caching in Cloudflare router for static/SSR sites

### DIFF
--- a/platform/functions/cf-ssr-site-router-worker/index.ts
+++ b/platform/functions/cf-ssr-site-router-worker/index.ts
@@ -62,7 +62,9 @@ export default {
         headers,
       });
 
-      await saveCache(response);
+      if (request.method === "GET") {
+        await saveCache(response);
+      }
 
       return response;
     }

--- a/platform/functions/cf-static-site-router-worker/index.ts
+++ b/platform/functions/cf-static-site-router-worker/index.ts
@@ -78,7 +78,9 @@ export default {
         headers,
       });
 
-      await saveCache(response);
+      if (request.method === "GET") {
+        await saveCache(response);
+      }
 
       return response;
     }


### PR DESCRIPTION
HEAD or POST requests currently result in this exception:

    {
      "stack": "    at saveCache (worker.mjs:71:19)\n    at respond (worker.mjs:85:13)\n    at fetch (worker.mjs:35:22)",
      "name": "TypeError",
      "message": "Cannot cache response to non-GET request.",
      "timestamp": 1722691361303
    }

Fixes sst/sst#4294