### PR TITLE
fix(install script): update get version command to new sst output format

### DIFF
--- a/install
+++ b/install
@@ -74,7 +74,7 @@ check_version() {
             exit 1
         fi
 
-        installed_version=$(sst version)
+        installed_version=$(./sst version | head -n 1 | awk '{print $2}')
 
         if [[ "$installed_version" != "$specific_version" ]]; then
             print_message info "Installed version: ${YELLOW}$installed_version."


### PR DESCRIPTION
Since the commit https://github.com/sst/ion/commit/5333a88635448bd933e3507733befad7236bf83e the install script is broken since the sst version command output changed. This fixes this by formatting the output using bash. Closes  sst/sst#4268