### PR TITLE
remix: fix vite config resolution in monorepos

### DIFF
--- a/platform/src/components/aws/remix.ts
+++ b/platform/src/components/aws/remix.ts
@@ -461,12 +461,15 @@ export class Remix extends Component implements Link.Linkable {
           const vite = await import("vite");
           const viteConfig = await vite.loadConfigFromFile(
             { command: "build", mode: "production" },
-            file,
+            path.join(sitePath, file),
           );
           if (!viteConfig) throw new Error();
 
           resolvedConfig = (await vite.resolveConfig(
-            viteConfig.config,
+            // root defaults to process.cwd(), which will be where the sst.config.ts file is located
+            // since we're invoking vite programatically. In a monorepo, this is likely incorrect, and
+            // should be the defined sitePath.
+            { ...viteConfig.config, root: viteConfig.config.root ?? sitePath },
             "build",
             "production",
           )) as Awaited<ReturnType<typeof vite.resolveConfig>> & {


### PR DESCRIPTION
this fixes the changes introduced in #736 in monorepos. in both the calls to `vite.loadConfigFromFile` and `vite.resolveConfig`, vite was resolving the root of the site as the cwd of the sst process, not the actual location of the site.  