### PR TITLE
docs(astro-sst): update wrong astro output

### DIFF
--- a/www/src/content/docs/docs/start/aws/astro.mdx
+++ b/www/src/content/docs/docs/start/aws/astro.mdx
@@ -43,7 +43,7 @@ It'll also ask you to update your `astro.config.mjs` with something like this.
 + import aws from "astro-sst";
 
 export default defineConfig({
-+  output: "dist",
++  output: "hybrid",
 +  adapter: aws()
 });
 ```

--- a/www/src/content/docs/docs/start/aws/astro.mdx
+++ b/www/src/content/docs/docs/start/aws/astro.mdx
@@ -43,7 +43,7 @@ It'll also ask you to update your `astro.config.mjs` with something like this.
 + import aws from "astro-sst";
 
 export default defineConfig({
-+  output: "hybrid",
++  output: "server",
 +  adapter: aws()
 });
 ```


### PR DESCRIPTION
The only valid astro output values are 'static' | 'server' | 'hybrid'

<img width="316" alt="image" src="https://github.com/user-attachments/assets/a225866a-4e75-4eb0-9df0-4a431561cbdb">
