### PR TITLE
fix: specific version installation for 3.0

### DIFF
--- a/install
+++ b/install
@@ -48,6 +48,9 @@ if [ -z "$requested_version" ]; then
     fi
 else
     url="https://github.com/sst/ion/releases/download/v${requested_version}/$filename"
+    if [ "${requested_version:0:1}" -ge 3 ]; then
+        url="https://github.com/sst/ion/releases/download/${requested_version}/$filename"
+    fi
     specific_version=$requested_version
 fi
 


### PR DESCRIPTION
Currently `curl -fsSL https://ion.sst.dev/install | VERSION=3.0.42 bash` fails because the script always uses 'v' prefix when downloading, but for 3.0+ there is no 'v' prefix.

Fixes: [879](https://github.com/sst/sst/issues/4269)