### PR TITLE
docs: Replace hardcoded-like AWS ARN values with placeholders for REGION and ACCOUNT

### DIFF
--- a/www/src/content/docs/docs/iam-credentials.mdx
+++ b/www/src/content/docs/docs/iam-credentials.mdx
@@ -191,7 +191,7 @@ Let's start with an IAM policy you can _copy and paste_.
               "ssm:PutParameter"
           ],
           "Resource": [
-              "arn:aws:ssm:us-east-1:112233445566:parameter/sst/*"
+              "arn:aws:ssm:REGION:ACCOUNT:parameter/sst/*"
           ]
       },
       {
@@ -325,7 +325,7 @@ The following block is placed as a template in the IAM policy above for you to c
 }
 ```
 
-Below we'll look at how you can try customizing this. 
+Below we'll look at how you can try customizing this.
 
 ---
 
@@ -387,4 +387,4 @@ Editing the above policy based on the resources you are adding to your app can b
 
   You can now use this for your production accounts. Learn more about how to use the [IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-policy-generation.html).
 
-In general, you want to make sure you audit the IAM permissions you are granting on a regular basis. 
+In general, you want to make sure you audit the IAM permissions you are granting on a regular basis.


### PR DESCRIPTION
# Overview

Replaced hardcoded-like AWS ARN values with placeholders for REGION and ACCOUNT.

# Background

In the sst documentation of [Docs] - [HOW TO] - [IAM Credentials] page, there is an example IAM policy json code as you can see on below image. ([Link](https://sst.dev/docs/iam-credentials/#iam-permissions))

<img width="743" alt="image" src="https://github.com/user-attachments/assets/9fec67e9-07c7-45a4-9fd1-5a21d546144c">

I found that there were hardcoded-like AWS ARN values for REGION and ACCOUNT like below, although others are already replaced with placeholders(REGION, ACCOUNT).

```diff
{
    "Sid": "ManageSecrets",
    "Effect": "Allow",
    "Action": [
        "ssm:DeleteParameter",
        "ssm:GetParameter",
        "ssm:GetParameters",
        "ssm:GetParametersByPath",
        "ssm:PutParameter"
    ],
    "Resource": [
+       "arn:aws:ssm:us-east-1:112233445566:parameter/sst/*"
    ]
},
```

# Changed

So, I replaced them with placeholders.

```diff
{
    "Sid": "ManageSecrets",
    "Effect": "Allow",
    "Action": [
        "ssm:DeleteParameter",
        "ssm:GetParameter",
        "ssm:GetParameters",
        "ssm:GetParametersByPath",
        "ssm:PutParameter"
    ],
    "Resource": [
-       "arn:aws:ssm:us-east-1:112233445566:parameter/sst/*"
+       "arn:aws:ssm:REGION:ACCOUNT:parameter/sst/*"
    ]
},
```

Thanks for sst team's efforts!