### PR TITLE
Implementing lambda authorizer for API Gateway v2

### DIFF
--- a/platform/src/components/aws/apigatewayv2-authorizer.ts
+++ b/platform/src/components/aws/apigatewayv2-authorizer.ts
@@ -1,8 +1,15 @@
-import { ComponentResourceOptions, Input, output } from "@pulumi/pulumi";
+import {
+  ComponentResourceOptions,
+  Input,
+  Output,
+  output,
+} from "@pulumi/pulumi";
 import { Component, transform } from "../component";
 import { ApiGatewayV2AuthorizerArgs } from "./apigatewayv2";
-import { apigatewayv2 } from "@pulumi/aws";
-
+import { apigatewayv2, lambda } from "@pulumi/aws";
+import { VisibleError } from "../error";
+import { Function } from "./function";
+import { interpolate } from "@pulumi/pulumi";
 export interface AuthorizerArgs extends ApiGatewayV2AuthorizerArgs {
   /**
    * The API Gateway to use for the route.
@@ -16,6 +23,10 @@ export interface AuthorizerArgs extends ApiGatewayV2AuthorizerArgs {
      * The ID of the API Gateway.
      */
     id: Input<string>;
+    /**
+     * The execution ARN of the API Gateway.
+     */
+    executionArn: Input<string>;
   }>;
 }
 
@@ -31,7 +42,8 @@ export interface AuthorizerArgs extends ApiGatewayV2AuthorizerArgs {
  */
 export class ApiGatewayV2Authorizer extends Component {
   private readonly authorizer: apigatewayv2.Authorizer;
-
+  private readonly fn?: Output<Function>;
+  private readonly permission?: lambda.Permission;
   constructor(
     name: string,
     args: AuthorizerArgs,
@@ -42,32 +54,126 @@ export class ApiGatewayV2Authorizer extends Component {
     const self = this;
 
     const api = output(args.api);
-    const jwt = output(args.jwt);
+    validateSingleAuthorizer();
+    validateFunctionExistsIfCustomAuthorizer();
+    const type = getType();
+    const identitySources = getIdentitySources();
+    const fn = createFunction();
 
     const authorizer = createAuthorizer();
+    const permission = createPermission();
 
     this.authorizer = authorizer;
+    this.fn = fn;
+    this.permission = permission;
+
+    function validateSingleAuthorizer() {
+      const authorizers = [args.custom, args.jwt].filter((e) => e);
+
+      if (!args.custom && !args.jwt)
+        throw new VisibleError(
+          `Please provide one of "custom" or "jwt" for the ${args.name} authorizer.`,
+        );
+
+      if (args.jwt && args.custom) {
+        throw new VisibleError(
+          `Please provide only one of "custom" or "jwt" for the ${args.name} authorizer.`,
+        );
+      }
+    }
+
+    function validateFunctionExistsIfCustomAuthorizer() {
+      if (!args.custom) return;
+      output(args.custom).apply((custom) => {
+        if (!custom?.function) {
+          throw new VisibleError(
+            `Please provide a function for the ${args.name} authorizer.`,
+          );
+        }
+      });
+    }
+
+    function getType() {
+      if (args.jwt) return "JWT";
+      if (args.custom) return "REQUEST";
+    }
+
+    function getIdentitySources() {
+      if (args.jwt) {
+        return [
+          output(args.jwt).apply(
+            (jwt) => jwt.identitySource ?? "$request.header.Authorization",
+          ),
+        ];
+      }
+      if (args.custom) {
+        return output(args.custom).apply(
+          (custom) =>
+            custom.identitySources ?? ["$request.header.Authorization"],
+        );
+      }
+    }
+
+    function createFunction() {
+      if (!args.custom) return;
+      return Function.fromDefinition(
+        `${name}Function`,
+        output(args.custom).function,
+        {
+          description: interpolate`${api.name} authorizer`,
+        },
+      );
+    }
 
     function createAuthorizer() {
+      if (args.jwt) {
+        return new apigatewayv2.Authorizer(
+          ...transform(
+            args.transform?.authorizer,
+            `${name}Authorizer`,
+            {
+              apiId: api.id,
+              authorizerType: type!,
+              identitySources: identitySources,
+              jwtConfiguration: output(args.jwt).apply((jwt) => ({
+                audiences: jwt.audiences,
+                issuer: jwt.issuer,
+              })),
+            },
+            { parent: self },
+          ),
+        );
+      }
       return new apigatewayv2.Authorizer(
         ...transform(
           args.transform?.authorizer,
           `${name}Authorizer`,
           {
             apiId: api.id,
-            authorizerType: "JWT",
-            identitySources: [
-              jwt.apply(
-                (jwt) => jwt.identitySource ?? "$request.header.Authorization",
-              ),
-            ],
-            jwtConfiguration: jwt.apply((jwt) => ({
-              audiences: jwt.audiences,
-              issuer: jwt.issuer,
-            })),
+            authorizerType: type!,
+            identitySources: identitySources,
+            authorizerResultTtlInSeconds: output(args.custom).apply(
+              (custom) => custom!.ttl ?? 300,
+            ),
+            authorizerPayloadFormatVersion: "2.0",
+            authorizerUri: fn?.nodes.function.invokeArn,
           },
           { parent: self },
         ),
+      );
+    }
+
+    function createPermission() {
+      if (!fn || !authorizer) return;
+      return new lambda.Permission(
+        `${name}Permission`,
+        {
+          action: "lambda:InvokeFunction",
+          function: fn.arn,
+          principal: "apigateway.amazonaws.com",
+          sourceArn: interpolate`${api.executionArn}/authorizers/${authorizer.id}`,
+        },
+        { parent: self },
       );
     }
   }
@@ -83,11 +189,23 @@ export class ApiGatewayV2Authorizer extends Component {
    * The underlying [resources](/docs/components/#nodes) this component creates.
    */
   public get nodes() {
+    const self = this;
+
     return {
       /**
        * The API Gateway V2 authorizer.
        */
       authorizer: this.authorizer,
+      /**
+       * The Lambda function used by the authorizer.
+       */
+      get function() {
+        if (!self.fn)
+          throw new VisibleError(
+            "Cannot access `nodes.function` because the data source does not use a Lambda function.",
+          );
+        return self.fn;
+      },
     };
   }
 }

--- a/platform/src/components/aws/apigatewayv2-base-route.ts
+++ b/platform/src/components/aws/apigatewayv2-base-route.ts
@@ -41,6 +41,12 @@ export function createApiRoute(
         authorizationScopes: auth.jwt.scopes,
         authorizerId: auth.jwt.authorizer,
       };
+    if (auth?.custom) {
+      return {
+        authorizationType: "CUSTOM",
+        authorizerId: auth.custom,
+      };
+    }
     return { authorizationType: "NONE" };
   });
 

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -341,7 +341,7 @@ export interface ApiGatewayV2AuthorizerArgs {
    * const userPoolClient = new aws.cognito.UserPoolClient();
    * ```
    */
-  jwt: Input<{
+  jwt?: Input<{
     /**
      * Base domain of the identity provider that issues JSON Web Tokens.
      * @example
@@ -361,6 +361,50 @@ export interface ApiGatewayV2AuthorizerArgs {
      * @default `"$request.header.Authorization"`
      */
     identitySource?: Input<string>;
+  }>;
+  /**
+    * Create a Lambda authorizer that can be used by the routes.
+
+    * @example
+    * Configure a custom authorizer.
+    *
+    * ```js
+    * {
+    *   custom: {
+    *     function: "src/authorizer.index"
+    *   }
+    * }
+    * ```
+    *
+  */
+  custom?: Input<{
+    /**
+     * The Lambda request authorizer function. Takes the handler path or the function args.
+     * @example
+     * ```js
+     * {
+     *   function: "src/authorizer.index"
+     * }
+     * ```
+     */
+    function: Input<string | FunctionArgs>;
+
+    /**
+     * Specifies where to extract the information that is required to identify the client.
+     * @default []
+     */
+    identitySources?: Input<Input<string>[]>;
+    /**
+     * Time to live for cached authorizer results in seconds.
+     * @default `300`
+     * @example
+     * ```js
+     * {
+     *   ttl: 30
+     * }
+     * ```
+     */
+    ttl?: Input<number>;
   }>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
@@ -425,6 +469,27 @@ export interface ApiGatewayV2RouteArgs {
        */
       scopes?: Input<Input<string>[]>;
     }>;
+    /**
+     * Enable custom Lambda authorization for a given API route. Pass in the authorizer ID.
+     * @example
+     * ```js
+     * {
+     *   auth: {
+     *     custom: myAuthorizer.id
+     *   }
+     * }
+     * ```
+     *
+     * Where `myAuthorizer` is:
+     *
+     * ```js
+     * api.addAuthorizer({
+     *  name: "myAuthorizer",
+     *  function: "src/authorizer.index"
+     * });
+     * ```
+     */
+    custom?: Input<string>;
   }>;
   /**
    * [Transform](/docs/components#transform) how this component creates its underlying
@@ -1126,6 +1191,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
       api: {
         id: self.api.id,
         name: selfName,
+        executionArn: self.api.executionArn,
       },
       ...args,
     });


### PR DESCRIPTION
I have tried replicating the apigatewayv1 api as close as possible without changing the current api for the jwt authorizer. 

Closes sst/sst#4606

Tell me if there is need for further changes. 

While this isn't merged you can use this transform:

```
const authorizer = new aws.apigatewayv2.Authorizer(
	"ApiAuthorizer",
	{
		apiId: api.nodes.api.id,
		authorizerType: "REQUEST",
		authorizerUri: authorizerFn.nodes.function.invokeArn,
		identitySources: [],
		authorizerResultTtlInSeconds: 300,
		authorizerPayloadFormatVersion: "2.0",
	}
);

export const route = (path, args, config = {}) =>
	api.route(path, args, {
		...config,
		transform: {
			route: {
				authorizationType: "CUSTOM",
				authorizerId: authorizer?.id,
			},
		},
	});

new aws.lambda.Permission(`AuthorizerPermission`, {
	action: "lambda:InvokeFunction",
	function: authorizerFn.arn,
	principal: "apigateway.amazonaws.com",
	sourceArn: $interpolate`${searchApi.nodes.api.executionArn}/authorizers/${authorizer.id}`,
});
```