### PR TITLE
feat(realtime): Add the ability to provide custom authorizer fields

### DIFF
--- a/sdk/js/src/aws/realtime.ts
+++ b/sdk/js/src/aws/realtime.ts
@@ -1,4 +1,4 @@
-import { Context, IoTCustomAuthorizerEvent } from "aws-lambda";
+import { IoTCustomAuthorizerHandler } from "aws-lambda";
 
 /**
  * The `realtime` client SDK is available through the following.
@@ -10,6 +10,21 @@ import { Context, IoTCustomAuthorizerEvent } from "aws-lambda";
  */
 export module realtime {
   export interface AuthResult {
+    /**
+     * The principal ID of the authorized client. This could be (but is not limited to) a user ID, an email address, or a phone number.
+     */
+    principalId?: string;
+
+    /**
+     * How long the client should be disconnected after the token expires.
+     */
+    disconnectAfterInSeconds?: number;
+
+    /**
+     * How long the client should be refreshed after the token expires.
+     */
+    refreshAfterInSeconds?: number;
+
     /**
      * The topics the client can subscribe to.
      * @example
@@ -28,6 +43,7 @@ export module realtime {
      * ```
      */
     subscribe?: string[];
+
     /**
      * The topics the client can publish to.
      * @example
@@ -65,19 +81,27 @@ export module realtime {
    * });
    * ```
    */
-  export function authorizer(input: (token: string) => Promise<AuthResult>) {
-    return async (evt: IoTCustomAuthorizerEvent, context: Context) => {
+  export function authorizer(
+    input: (token: string) => Promise<AuthResult>
+  ): IoTCustomAuthorizerHandler {
+    return async (evt, context) => {
       const [, , , region, accountId] = context.invokedFunctionArn.split(":");
       const token = Buffer.from(
         evt.protocolData.mqtt?.password ?? "",
         "base64"
       ).toString();
-      const ret = await input(token);
+      const {
+        principalId = evt.protocolData.mqtt?.username || Date.now().toString(),
+        disconnectAfterInSeconds = 86400,
+        refreshAfterInSeconds = 300,
+        subscribe,
+        publish,
+      } = await input(token);
       return {
         isAuthenticated: true,
-        principalId: Date.now().toString(),
-        disconnectAfterInSeconds: 86400,
-        refreshAfterInSeconds: 300,
+        principalId,
+        disconnectAfterInSeconds,
+        refreshAfterInSeconds,
         policyDocuments: [
           {
             Version: "2012-10-17",
@@ -87,39 +111,39 @@ export module realtime {
                 Effect: "Allow",
                 Resource: "*",
               },
-              ...(ret.subscribe
+              ...(subscribe
                 ? [
-                  {
-                    Action: "iot:Receive",
-                    Effect: "Allow",
-                    Resource: ret.subscribe.map(
-                      (t) => `arn:aws:iot:${region}:${accountId}:topic/${t}`
-                    ),
-                  },
-                ]
+                    {
+                      Action: "iot:Receive",
+                      Effect: "Allow",
+                      Resource: subscribe.map(
+                        (t) => `arn:aws:iot:${region}:${accountId}:topic/${t}`
+                      ),
+                    },
+                  ]
                 : []),
-              ...(ret.subscribe
+              ...(subscribe
                 ? [
-                  {
-                    Action: "iot:Subscribe",
-                    Effect: "Allow",
-                    Resource: ret.subscribe.map(
-                      (t) =>
-                        `arn:aws:iot:${region}:${accountId}:topicfilter/${t}`
-                    ),
-                  },
-                ]
+                    {
+                      Action: "iot:Subscribe",
+                      Effect: "Allow",
+                      Resource: subscribe.map(
+                        (t) =>
+                          `arn:aws:iot:${region}:${accountId}:topicfilter/${t}`
+                      ),
+                    },
+                  ]
                 : []),
-              ...(ret.publish
+              ...(publish
                 ? [
-                  {
-                    Action: "iot:Publish",
-                    Effect: "Allow",
-                    Resource: ret.publish.map(
-                      (t) => `arn:aws:iot:${region}:${accountId}:topic/${t}`
-                    ),
-                  },
-                ]
+                    {
+                      Action: "iot:Publish",
+                      Effect: "Allow",
+                      Resource: publish.map(
+                        (t) => `arn:aws:iot:${region}:${accountId}:topic/${t}`
+                      ),
+                    },
+                  ]
                 : []),
             ],
           },

--- a/sdk/js/src/aws/realtime.ts
+++ b/sdk/js/src/aws/realtime.ts
@@ -1,4 +1,4 @@
-import { IoTCustomAuthorizerHandler } from "aws-lambda";
+import { IoTCustomAuthorizerHandler, PolicyDocument } from "aws-lambda";
 
 /**
  * The `realtime` client SDK is available through the following.
@@ -61,6 +61,28 @@ export module realtime {
      * ```
      */
     publish?: string[];
+
+    /**
+     * Any additional policy documents to attach to the client.
+     * @example
+     * ```js
+     * {
+     *   policyDocuments: [
+     *     {
+     *       Version: "2012-10-17",
+     *       Statement: [
+     *         {
+     *           Action: "iot:GetThingShadow",
+     *           Effect: "Allow",
+     *           Resource: "*",
+     *         },
+     *       ],
+     *     },
+     *   ],
+     * };
+     * ```
+     */
+    policyDocuments?: PolicyDocument[];
   }
 
   /**
@@ -96,6 +118,7 @@ export module realtime {
         refreshAfterInSeconds = 300,
         subscribe,
         publish,
+        policyDocuments,
       } = await input(token);
       return {
         isAuthenticated: true,
@@ -147,6 +170,7 @@ export module realtime {
                 : []),
             ],
           },
+          ...(policyDocuments ?? []),
         ],
       };
     };

--- a/www/src/content/docs/docs/component/aws/realtime.mdx
+++ b/www/src/content/docs/docs/component/aws/realtime.mdx
@@ -46,9 +46,11 @@ import { realtime } from "sst/aws/realtime";
 
 export const handler = realtime.authorizer(async (token) => {
   // Validate the token
+  const { userId } = validateToken(token);
 
   // Return the topics to subscribe and publish
   return {
+    principalId: `${Resource.App.name}/${Resource.App.stage}/${userId}`,
     subscribe: [`${Resource.App.name}/${Resource.App.stage}/chat/room1`],
     publish: [`${Resource.App.name}/${Resource.App.stage}/chat/room1`],
   };


### PR DESCRIPTION
Updated the docs to include an example of providing one of the new options: `principalId`.

This opens the door for adding shadows to the IoT device including auth data via the principalId.