### PR TITLE
docs: Correct postgres documentation error

### DIFF
--- a/platform/src/components/aws/postgres.ts
+++ b/platform/src/components/aws/postgres.ts
@@ -85,7 +85,7 @@ export interface PostgresArgs {
      */
     min?: Input<ACU>;
     /**
-     * The maximum number of ACUs, ranges from 0.5 to 128, in increments of 0.5.
+     * The maximum number of ACUs, ranges from 1 to 128, in increments of 0.5.
      *
      * @default `4 ACU`
      * @example


### PR DESCRIPTION
Documentation currently states that the maximum ACU range that can be configured on Aurora Postgres serverless v2 is between 0.5 to 128, but the actual range is 1 to 128.

If you try to configure a max ACU of 0.5 you'll get the following error:
```InvalidParameterValue: Serverless v2 maximum capacity 0.5 isn't valid. The maximum capacity must be at least 1.0.```

The range can also be seen on the AWS Console:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/9a7d35c8-0785-49d3-95c5-a04edd2989fc">

