### PR TITLE
clarify where to run the live command from

### DIFF
--- a/www/src/content/docs/docs/live.mdx
+++ b/www/src/content/docs/docs/live.mdx
@@ -154,7 +154,7 @@ Since Live runs your functions locally, you can set breakpoints and debug your f
 For VS Code, you'll need to enable Auto Attach from the Command Palette. Hit `Ctrl+Shift+P` or `Cmd+Shift+P`, type in **Debug: Toggle Auto Attach** and select **Always**.
 
 :::note
-You need to start a new terminal after enabling Auto Attach.
+You need to start a new terminal **in VS Code** after enabling Auto Attach.
 :::
 
-Now open a new terminal VS Code, run `sst dev`, set a breakpoint in a function, and invoke the function.
+Now open a new terminal in VS Code, run `sst dev`, set a breakpoint in a function, and invoke the function.


### PR DESCRIPTION
After spending time researching is that I realized VS Code requires it to be executed from within their terminal windows.