### PR TITLE
Fix: Add .profile to config_files for bash

### DIFF
--- a/install
+++ b/install
@@ -123,7 +123,7 @@ case $current_shell in
         config_files="$HOME/.zshrc $HOME/.zshenv $XDG_CONFIG_HOME/zsh/.zshrc $XDG_CONFIG_HOME/zsh/.zshenv"
     ;;
     bash)
-        config_files="$HOME/.bashrc $HOME/.bash_profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+        config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
     ;;
     ash)
         config_files="$HOME/.ashrc $HOME/.profile /etc/profile"


### PR DESCRIPTION
Adds the missing the .profile config file for bash