### PR TITLE
fix: Input<> types for handler/subscriber parameters

### DIFF
--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -525,7 +525,7 @@ export class ApiGatewayWebSocket extends Component implements Link.Linkable {
    */
   public route(
     route: string,
-    handler: string | FunctionArgs | FunctionArn,
+    handler: Input<string | FunctionArgs | FunctionArn>,
     args: ApiGatewayWebSocketRouteArgs = {},
   ) {
     const prefix = this.constructorName;

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -601,7 +601,7 @@ export class Bucket extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BucketSubscriberArgs,
   ) {
     this.ensureNotSubscribed();
@@ -664,7 +664,7 @@ export class Bucket extends Component implements Link.Linkable {
    */
   public static subscribe(
     bucketArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BucketSubscriberArgs,
   ) {
     return output(bucketArn).apply((bucketArn) => {
@@ -683,7 +683,7 @@ export class Bucket extends Component implements Link.Linkable {
     name: string,
     bucketName: Input<string>,
     bucketArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BucketSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/bus.ts
+++ b/platform/src/components/aws/bus.ts
@@ -254,7 +254,7 @@ export class Bus extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BusSubscriberArgs = {},
   ) {
     return Bus._subscribeFunction(
@@ -309,7 +309,7 @@ export class Bus extends Component implements Link.Linkable {
    */
   public static subscribe(
     busArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BusSubscriberArgs,
   ) {
     return output(busArn).apply((busArn) => {
@@ -328,7 +328,7 @@ export class Bus extends Component implements Link.Linkable {
     name: string,
     busName: Input<string>,
     busArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BusSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/queue.ts
+++ b/platform/src/components/aws/queue.ts
@@ -437,7 +437,7 @@ export class Queue extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
@@ -502,7 +502,7 @@ export class Queue extends Component implements Link.Linkable {
    */
   public static subscribe(
     queueArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
@@ -520,7 +520,7 @@ export class Queue extends Component implements Link.Linkable {
   private static _subscribeFunction(
     name: string,
     queueArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: QueueSubscriberArgs = {},
     opts?: ComponentResourceOptions,
   ) {

--- a/platform/src/components/aws/realtime.ts
+++ b/platform/src/components/aws/realtime.ts
@@ -295,7 +295,7 @@ export class Realtime extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: RealtimeSubscriberArgs,
   ) {
     return all([subscriber, args.filter]).apply(([subscriber, filter]) => {

--- a/platform/src/components/aws/sns-topic.ts
+++ b/platform/src/components/aws/sns-topic.ts
@@ -253,7 +253,7 @@ export class SnsTopic extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: SnsTopicSubscriberArgs = {},
   ) {
     return SnsTopic._subscribeFunction(
@@ -307,7 +307,7 @@ export class SnsTopic extends Component implements Link.Linkable {
    */
   public static subscribe(
     topicArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: SnsTopicSubscriberArgs,
   ) {
     return output(topicArn).apply((topicArn) =>
@@ -323,7 +323,7 @@ export class SnsTopic extends Component implements Link.Linkable {
   private static _subscribeFunction(
     name: string,
     topicArn: Input<string>,
-    subscriber: string | FunctionArgs | FunctionArn,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: SnsTopicSubscriberArgs = {},
     opts: $util.ComponentResourceOptions = {},
   ) {


### PR DESCRIPTION
This commit updates several AWS components to accept Input<> types for handler and subscriber parameters. The change affects the following components:

- ApiGatewayWebSocket
- Bucket
- Bus
- Queue
- Realtime
- SnsTopic

I think similar problem exists in KinesisStream, Dynamo, ApiGatewayV1; but It was not an easy fix for me :) 

This solves the problem discussed in [#1057](https://github.com/sst/sst/issues/4128)