### PR TITLE
Allow underscores in the secret name

### DIFF
--- a/cmd/sst/secret.go
+++ b/cmd/sst/secret.go
@@ -326,7 +326,7 @@ var CmdSecretSet = &cli.Command{
 				}
 			}
 		}
-		if !regexp.MustCompile(`^[A-Z][a-zA-Z0-9]*$`).MatchString(key) {
+		if !regexp.MustCompile(`^[A-Z][a-zA-Z0-9_]*$`).MatchString(key) {
 			return util.NewReadableError(nil, "Secret names must start with a capital letter and contain only letters and numbers")
 		}
 		p, err := c.InitProject()


### PR DESCRIPTION
It should fix this issue:

```sh
npx sst version
sst 3.1.11

npx sst secret set OPENAI_API_KEY ab-cd-efg12345
✕  Secret names must start with a capital letter and contain only letters and numbers
```