### PR TITLE
fix: change Cloudfront Function handler to async function where code injection happens

### DIFF
--- a/platform/src/components/aws/router.ts
+++ b/platform/src/components/aws/router.ts
@@ -605,7 +605,7 @@ export class Router extends Component implements Link.Linkable {
           runtime: "cloudfront-js-2.0",
           keyValueStoreAssociations: config?.kvStores ?? [],
           code: `
-function handler(event) {
+async function handler(event) {
   ${
     injectHostHeader
       ? `event.request.headers["x-forwarded-host"] = event.request.headers.host;`
@@ -639,7 +639,7 @@ event.request.uri = event.request.uri.replace(re, "${rewrite.to}");`
           runtime: "cloudfront-js-2.0",
           keyValueStoreAssociations: config!.kvStores ?? [],
           code: `
-function handler(event) {
+async function handler(event) {
   ${config.injection ?? ""}
   return event.response;
 }`,


### PR DESCRIPTION
This Pull Request modifies the Cloudfront function handler to be async in the sections where users can inject custom code. 

This change is necessary to accommodate scenarios where asynchronous operations, such as accessing the Cloudfront KV store or when `await` is required in the user provided code.