### PR TITLE
docs: typo existig → existing

### DIFF
--- a/platform/src/components/aws/vpc-v1.ts
+++ b/platform/src/components/aws/vpc-v1.ts
@@ -78,7 +78,7 @@ interface VpcRef {
  * The `Vpc` component lets you add a VPC to your app, but it has been deprecated because
  * it does not support modifying the number of Availability Zones (AZs) after VPC creation.
  *
- * For existig usage, rename `sst.aws.Vpc` to `sst.aws.Vpc.v1`. For new VPCs, use
+ * For existing usage, rename `sst.aws.Vpc` to `sst.aws.Vpc.v1`. For new VPCs, use
  * the latest [`Vpc`](/docs/component/aws/vpc) component instead.
  *
  * :::caution


### PR DESCRIPTION
Can be seen here: https://sst.dev/docs/component/aws/vpc-v1