### PR TITLE
feat: add provided.al2 to runtime enum

### DIFF
--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -1056,6 +1056,11 @@ export interface FunctionArgs {
    * @internal
    */
   _skipMetadata?: boolean;
+
+  /**
+   * If enabled, it does not create an lambda wrapper which makes it possible to use with different custom runtimes like PHP
+   */
+  skipHandlerWrapper?: Input<boolean>
 }
 
 /**
@@ -1530,7 +1535,7 @@ export class Function extends Component implements Link.Linkable {
           runtime,
         ]) => {
           if (dev) return { handler };
-          if (runtime.startsWith("python")) {
+          if (runtime.startsWith("python") || args.skipHandlerWrapper) {
             return { handler };
           }
 

--- a/platform/src/components/aws/function.ts
+++ b/platform/src/components/aws/function.ts
@@ -261,13 +261,14 @@ export interface FunctionArgs {
    * ```
    */
   runtime?: Input<
-    | "nodejs18.x"
-    | "nodejs20.x"
-    | "provided.al2023"
-    | "python3.9"
-    | "python3.10"
-    | "python3.11"
-    | "python3.12"
+  | "nodejs18.x"
+  | "nodejs20.x"
+  | "provided.al2023"
+  | "provided.al2"
+  | "python3.9"
+  | "python3.10"
+  | "python3.11"
+  | "python3.12"
   >;
   /**
    * Path to the source code directory for the function. By default, the handler is


### PR DESCRIPTION
I am trying to get PHP running in lambda and need provided.al2  as al2023 is not supported yet https://github.com/brefphp/bref/issues/1856

working php lambda:

```ts
    const frontend = new sst.aws.Function('php', {
      handler: 'public/index.php',
      bundle: 'app',
      architecture: 'arm64',
      runtime: 'provided.al2',
      url: true,
      layers: [
        'arn:aws:lambda:eu-central-1:534081306603:layer:arm-php-84-fpm:8'
      ],
      link: [table],
      environment: {
        APP_ENV: 'prod',
        APP_DEBUG: '0',
        SHOPWARE_APP_NAME: 'SymfonyServerless',
        SHOPWARE_APP_SECRET: 'SymfonyServerless',
        DYNAMODB_TABLE_NAME: table.name,
      },
      skipHandlerWrapper: true
    });
```