### PR TITLE
fix: tRPC example to support 11.x types

### DIFF
--- a/examples/aws-trpc/index.ts
+++ b/examples/aws-trpc/index.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import {
-  APIGatewayEvent,
   awsLambdaRequestHandler,
   CreateAWSLambdaContextOptions
 } from "@trpc/server/adapters/aws-lambda";
 import { initTRPC } from "@trpc/server";
+import { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
 
 const t = initTRPC
-  .context<CreateAWSLambdaContextOptions<APIGatewayEvent>>()
+  .context<CreateAWSLambdaContextOptions<APIGatewayProxyEvent | APIGatewayProxyEventV2>>()
   .create();
 
 const router = t.router({

--- a/examples/aws-trpc/package.json
+++ b/examples/aws-trpc/package.json
@@ -10,9 +10,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@trpc/client": "11.0.0-rc.340",
-    "@trpc/server": "11.0.0-rc.340",
+    "@trpc/client": "^11.0.0-rc.528",
+    "@trpc/server": "^11.0.0-rc.528",
     "sst": "latest",
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.145"
   }
 }

--- a/www/src/content/docs/docs/start/aws/trpc.mdx
+++ b/www/src/content/docs/docs/start/aws/trpc.mdx
@@ -87,7 +87,7 @@ Let's create our tRPC server. Add the following to `index.ts`.
 
 ```ts title="index.ts"
 const t = initTRPC
-  .context<CreateAWSLambdaContextOptions<APIGatewayEvent>>()
+  .context<CreateAWSLambdaContextOptions<APIGatewayProxyEvent | APIGatewayProxyEventV2>>()
   .create();
 
 const router = t.router({
@@ -113,11 +113,11 @@ Add the imports.
 ```ts title="index.ts"
 import { z } from "zod";
 import {
-  APIGatewayEvent,
   awsLambdaRequestHandler,
   CreateAWSLambdaContextOptions
 } from "@trpc/server/adapters/aws-lambda";
 import { initTRPC } from "@trpc/server";
+import { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from "aws-lambda";
 ```
 
 And install the npm packages.


### PR DESCRIPTION
Updated the tRPC example guide to support the latest version of tRPC 11.x (next).
Accepted types of `CreateAWSLambdaContextOptions` has changed to

```js
export type LambdaEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2;
```
Reference: 
https://github.com/trpc/trpc/blob/next/packages/server/src/adapters/aws-lambda/getPlanner.ts#L8
https://trpc.io/docs/server/adapters/aws-lambda#a-word-about-payload-format-version
