### PR TITLE
Clarify documentation version

### DIFF
--- a/www/src/content/docs/docs/index.mdx
+++ b/www/src/content/docs/docs/index.mdx
@@ -11,7 +11,7 @@ export const github  = config.github;
 SST is a framework that makes it easy to build modern full-stack applications on your own infrastructure.
 
 :::note
-If you are looking for SST v2, you can head over to [v2.sst.dev](https://v2.sst.dev).
+This is the documentation for SST v3. If you are looking for SST v2, you can head over to [v2.sst.dev](https://v2.sst.dev).
 :::
 
 What makes SST different is that your _entire_ app is **defined in code** — in a single `sst.config.ts` file. This includes databases, buckets, queues, Stripe webhooks, or any one of **150+ providers**.


### PR DESCRIPTION
I just started reading up on SST. I got confused by the tip message since I thought I was on the v1 documentation. This change clarifies which version is documented.

I didn't raise an issue for this, sorry about that! Forking, making the change and opening a PR took no more than 2 minutes, so just reject it if you don't agree.

Cheers,
Malcolm