### PR TITLE
nuxt: detect Nuxt when using app.config.ts in project

### DIFF
--- a/cmd/sst/init.go
+++ b/cmd/sst/init.go
@@ -79,18 +79,18 @@ func CmdInit(cli *cli.Cli) error {
 		template = "astro"
 		break
 
-	case slices.ContainsFunc(hints, func(s string) bool { return strings.HasPrefix(s, "app.config") }):
-		fmt.Println("  SolidStart detected. This will...")
-		fmt.Println("   - create an sst.config.ts")
-		fmt.Println("   - add sst to package.json")
-		template = "solid-start"
-		break
-
 	case slices.ContainsFunc(hints, func(s string) bool { return strings.HasPrefix(s, "nuxt.config") }):
 		fmt.Println("  Nuxt detected. This will...")
 		fmt.Println("   - create an sst.config.ts")
 		fmt.Println("   - add sst to package.json")
 		template = "nuxt"
+		break
+		
+	case slices.ContainsFunc(hints, func(s string) bool { return strings.HasPrefix(s, "app.config") }):
+		fmt.Println("  SolidStart detected. This will...")
+		fmt.Println("   - create an sst.config.ts")
+		fmt.Println("   - add sst to package.json")
+		template = "solid-start"
 		break
 
 	case slices.ContainsFunc(hints, func(s string) bool { return strings.HasPrefix(s, "svelte.config") }):


### PR DESCRIPTION
Issue: app.config.ts is used in apps with nuxt ui/ui-pro packages from the nuxt team. they use it to configure certain aspects. when this is here SST thinks it's solidstart

fixed it just by changing the order of the switch case

idk how to really run the project cause i've never used a go project before

Reference: https://ui.nuxt.com/getting-started/theming#appconfigts