### PR TITLE
Fix typo shel -> shell

### DIFF
--- a/www/src/content/docs/docs/examples.mdx
+++ b/www/src/content/docs/docs/examples.mdx
@@ -1232,7 +1232,7 @@ with the [`sst shell`](/docs/reference/cli) CLI.
 "db:generate": "sst shell drizzle-kit generate",
 "db:migrate": "sst shell drizzle-kit migrate",
 "db:push": "sst shell drizzle-kit push",
-"db:studio": "sst shel drizzle-kit studio",
+"db:studio": "sst shell drizzle-kit studio",
 ```
 
 So running `npm run db:push` will run Drizzle Kit with the right credentials.


### PR DESCRIPTION
Found a small typo in the T3 Stack example section