### PR TITLE
Parameterise NPM Registry url

### DIFF
--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 )
 
 type Package struct {
@@ -18,7 +19,11 @@ type Package struct {
 
 func Get(name string, version string) (*Package, error) {
 	slog.Info("getting package", "name", name, "version", version)
-	url := "https://registry.npmjs.org/" + name + "/" + version
+	baseUrl := os.Getenv("NPM_REGISTRY")
+	if baseUrl == "" {
+		baseUrl = "https://registry.npmjs.org"
+	}
+	url := fmt.Sprintf("%s/%s/%s", baseUrl, name, version)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Parameterise NPM Registry as environment variable in order to override the value, to make it working for corporate networks and private registries.

Fixes: https://github.com/sst/sst/issues/4113