### PR TITLE
fix: API GatewayV2 routes take Input<T> as handler

### DIFF
--- a/platform/src/components/aws/apigateway-websocket-route.ts
+++ b/platform/src/components/aws/apigateway-websocket-route.ts
@@ -7,7 +7,7 @@ import {
   output,
 } from "@pulumi/pulumi";
 import { Component, Transform, transform } from "../component";
-import { Function, FunctionArgs } from "./function";
+import { Function, FunctionArgs, FunctionArn } from "./function";
 import { ApiGatewayWebSocketRouteArgs } from "./apigateway-websocket";
 import { apigatewayv2, lambda } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
@@ -37,7 +37,7 @@ export interface Args extends ApiGatewayWebSocketRouteArgs {
   /**
    * The function that’ll be invoked.
    */
-  handler: Input<string | FunctionArgs>;
+  handler: Input<string | FunctionArgs | FunctionArn>;
   /**
    * @internal
    */

--- a/platform/src/components/aws/apigateway-websocket-route.ts
+++ b/platform/src/components/aws/apigateway-websocket-route.ts
@@ -1,13 +1,12 @@
 import {
   ComponentResourceOptions,
   Input,
-  Output,
   all,
   interpolate,
   output,
 } from "@pulumi/pulumi";
 import { Component, Transform, transform } from "../component";
-import { Function, FunctionArgs, FunctionArn } from "./function";
+import { FunctionArgs } from "./function";
 import { ApiGatewayWebSocketRouteArgs } from "./apigateway-websocket";
 import { apigatewayv2, lambda } from "@pulumi/aws";
 import { FunctionBuilder, functionBuilder } from "./helpers/function-builder";
@@ -37,7 +36,7 @@ export interface Args extends ApiGatewayWebSocketRouteArgs {
   /**
    * The function that’ll be invoked.
    */
-  handler: Input<string | FunctionArgs | FunctionArn>;
+  handler: Input<string | FunctionArgs>;
   /**
    * @internal
    */

--- a/platform/src/components/aws/apigateway-websocket.ts
+++ b/platform/src/components/aws/apigateway-websocket.ts
@@ -531,7 +531,7 @@ export class ApiGatewayWebSocket extends Component implements Link.Linkable {
    */
   public route(
     route: string,
-    handler: string | FunctionArgs | Input<FunctionArn>,
+    handler:  Input<string | FunctionArgs | FunctionArn>,
     args: ApiGatewayWebSocketRouteArgs = {},
   ) {
     const prefix = this.constructorName;

--- a/platform/src/components/aws/apigatewayv1-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv1-lambda-route.ts
@@ -6,7 +6,7 @@ import {
   output,
 } from "@pulumi/pulumi";
 import { Component, Transform, transform } from "../component";
-import { Function, FunctionArgs, FunctionArn } from "./function";
+import { FunctionArgs } from "./function";
 import { apigateway, lambda } from "@pulumi/aws";
 import {
   ApiGatewayV1BaseRouteArgs,
@@ -18,7 +18,7 @@ export interface Args extends ApiGatewayV1BaseRouteArgs {
   /**
    * The route function.
    */
-  handler: Input<string | FunctionArgs | FunctionArn>;
+  handler: Input<string | FunctionArgs>;
   /**
    * @internal
    */

--- a/platform/src/components/aws/apigatewayv1-lambda-route.ts
+++ b/platform/src/components/aws/apigatewayv1-lambda-route.ts
@@ -6,7 +6,7 @@ import {
   output,
 } from "@pulumi/pulumi";
 import { Component, Transform, transform } from "../component";
-import { Function, FunctionArgs } from "./function";
+import { Function, FunctionArgs, FunctionArn } from "./function";
 import { apigateway, lambda } from "@pulumi/aws";
 import {
   ApiGatewayV1BaseRouteArgs,
@@ -18,7 +18,7 @@ export interface Args extends ApiGatewayV1BaseRouteArgs {
   /**
    * The route function.
    */
-  handler: Input<string | FunctionArgs>;
+  handler: Input<string | FunctionArgs | FunctionArn>;
   /**
    * @internal
    */

--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -829,7 +829,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
    */
   public route(
     route: string,
-    handler: string | FunctionArgs | Input<FunctionArn>,
+    handler: Input<string | FunctionArgs | FunctionArn>,
     args: ApiGatewayV1RouteArgs = {},
   ) {
     const { method, path } = this.parseRoute(route);

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -1078,7 +1078,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    */
   public routeUrl(
     rawRoute: string,
-    url: Input<string>,
+    url: string,
     args: ApiGatewayV2RouteArgs = {},
   ) {
     const route = this.parseRoute(rawRoute);
@@ -1145,7 +1145,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    */
   public routePrivate(
     rawRoute: string,
-    arn: Input<string>,
+    arn: string,
     args: ApiGatewayV2RouteArgs = {},
   ) {
     if (!this.vpcLink)

--- a/platform/src/components/aws/apigatewayv2.ts
+++ b/platform/src/components/aws/apigatewayv2.ts
@@ -1025,7 +1025,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    */
   public route(
     rawRoute: string,
-    handler: string | FunctionArgs | Input<FunctionArn>,
+    handler: Input<string | FunctionArgs | FunctionArn>,
     args: ApiGatewayV2RouteArgs = {},
   ) {
     const route = this.parseRoute(rawRoute);
@@ -1078,7 +1078,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    */
   public routeUrl(
     rawRoute: string,
-    url: string,
+    url: Input<string>,
     args: ApiGatewayV2RouteArgs = {},
   ) {
     const route = this.parseRoute(rawRoute);
@@ -1145,7 +1145,7 @@ export class ApiGatewayV2 extends Component implements Link.Linkable {
    */
   public routePrivate(
     rawRoute: string,
-    arn: string,
+    arn: Input<string>,
     args: ApiGatewayV2RouteArgs = {},
   ) {
     if (!this.vpcLink)

--- a/platform/src/components/aws/bucket.ts
+++ b/platform/src/components/aws/bucket.ts
@@ -644,7 +644,7 @@ export class Bucket extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BucketSubscriberArgs,
   ) {
     this.ensureNotSubscribed();
@@ -707,7 +707,7 @@ export class Bucket extends Component implements Link.Linkable {
    */
   public static subscribe(
     bucketArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BucketSubscriberArgs,
   ) {
     return output(bucketArn).apply((bucketArn) => {
@@ -726,7 +726,7 @@ export class Bucket extends Component implements Link.Linkable {
     name: string,
     bucketName: Input<string>,
     bucketArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BucketSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/bus.ts
+++ b/platform/src/components/aws/bus.ts
@@ -254,7 +254,7 @@ export class Bus extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BusSubscriberArgs = {},
   ) {
     return Bus._subscribeFunction(
@@ -309,7 +309,7 @@ export class Bus extends Component implements Link.Linkable {
    */
   public static subscribe(
     busArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: BusSubscriberArgs,
   ) {
     return output(busArn).apply((busArn) => {
@@ -328,7 +328,7 @@ export class Bus extends Component implements Link.Linkable {
     name: string,
     busName: Input<string>,
     busArn: string | Output<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: BusSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/cognito-user-pool.ts
+++ b/platform/src/components/aws/cognito-user-pool.ts
@@ -24,7 +24,7 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  createAuthChallenge?: string | FunctionArgs | Input<FunctionArn>;
+  createAuthChallenge?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered during events like user sign-up, password recovery, email/phone number
    * verification, and when an admin creates a user. Use this trigger to customize the
@@ -32,7 +32,7 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  customEmailSender?: string | FunctionArgs | Input<FunctionArn>;
+  customEmailSender?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered during events like user sign-up, password recovery, email/phone number
    * verification, and when an admin creates a user. Use this trigger to customize the
@@ -40,14 +40,14 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  customMessage?: string | FunctionArgs | Input<FunctionArn>;
+  customMessage?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered when an SMS message needs to be sent, such as for MFA or verification codes.
    * Use this trigger to customize the SMS provider.
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  customSmsSender?: string | FunctionArgs | Input<FunctionArn>;
+  customSmsSender?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered after each challenge response to determine the next action. Evaluates whether the
    * user has completed the authentication process or if additional challenges are needed.
@@ -55,14 +55,14 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  defineAuthChallenge?: string | FunctionArgs | Input<FunctionArn>;
+  defineAuthChallenge?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered after a successful authentication event. Use this to perform custom actions,
    * such as logging or modifying user attributes, after the user is authenticated.
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  postAuthentication?: string | FunctionArgs | Input<FunctionArn>;
+  postAuthentication?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered after a user is successfully confirmed; sign-up or email/phone number
    * verification. Use this to perform additional actions, like sending a welcome email or
@@ -70,7 +70,7 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  postConfirmation?: string | FunctionArgs | Input<FunctionArn>;
+  postConfirmation?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered before the authentication process begins. Use this to implement custom
    * validation or checks (like checking if the user is banned) before continuing
@@ -78,21 +78,21 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  preAuthentication?: string | FunctionArgs | Input<FunctionArn>;
+  preAuthentication?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered before the user sign-up process completes. Use this to perform custom
    * validation, auto-confirm users, or auto-verify attributes based on custom logic.
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  preSignUp?: string | FunctionArgs | Input<FunctionArn>;
+  preSignUp?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered before tokens are generated in the authentication process. Use this to
    * customize or add claims to the tokens that will be generated and returned to the user.
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  preTokenGeneration?: string | FunctionArgs | Input<FunctionArn>;
+  preTokenGeneration?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * The version of the preTokenGeneration trigger to use. Higher versions have access to
    * more information that support new features.
@@ -106,7 +106,7 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  userMigration?: string | FunctionArgs | Input<FunctionArn>;
+  userMigration?: Input<string | FunctionArgs | FunctionArn>;
   /**
    * Triggered after the user responds to a custom authentication challenge. Use this to
    * verify the user's response to the challenge and determine whether to continue
@@ -114,7 +114,7 @@ interface Triggers {
    *
    * Takes the handler path, the function args, or a function ARN.
    */
-  verifyAuthChallengeResponse?: string | FunctionArgs | Input<FunctionArn>;
+  verifyAuthChallengeResponse?: Input<string | FunctionArgs | FunctionArn>;
 }
 
 export interface CognitoUserPoolArgs {

--- a/platform/src/components/aws/dynamo.ts
+++ b/platform/src/components/aws/dynamo.ts
@@ -562,7 +562,7 @@ export class Dynamo extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: DynamoSubscriberArgs,
   ) {
     const sourceName = this.constructorName;
@@ -632,7 +632,7 @@ export class Dynamo extends Component implements Link.Linkable {
    */
   public static subscribe(
     streamArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: DynamoSubscriberArgs,
   ) {
     return output(streamArn).apply((streamArn) =>
@@ -648,7 +648,7 @@ export class Dynamo extends Component implements Link.Linkable {
   private static _subscribe(
     name: string,
     streamArn: string | Output<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: DynamoSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/kinesis-stream.ts
+++ b/platform/src/components/aws/kinesis-stream.ts
@@ -195,7 +195,7 @@ export class KinesisStream extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: KinesisStreamLambdaSubscriberArgs,
   ) {
     return KinesisStream._subscribe(
@@ -255,7 +255,7 @@ export class KinesisStream extends Component implements Link.Linkable {
    */
   public static subscribe(
     streamArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: KinesisStreamLambdaSubscriberArgs,
   ) {
     return output(streamArn).apply((streamArn) =>
@@ -271,7 +271,7 @@ export class KinesisStream extends Component implements Link.Linkable {
   private static _subscribe(
     name: string,
     streamArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: KinesisStreamLambdaSubscriberArgs = {},
     opts: ComponentResourceOptions = {},
   ) {

--- a/platform/src/components/aws/queue.ts
+++ b/platform/src/components/aws/queue.ts
@@ -472,7 +472,7 @@ export class Queue extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
@@ -537,7 +537,7 @@ export class Queue extends Component implements Link.Linkable {
    */
   public static subscribe(
     queueArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: QueueSubscriberArgs,
     opts?: ComponentResourceOptions,
   ) {
@@ -555,7 +555,7 @@ export class Queue extends Component implements Link.Linkable {
   private static _subscribeFunction(
     name: string,
     queueArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: QueueSubscriberArgs = {},
     opts?: ComponentResourceOptions,
   ) {

--- a/platform/src/components/aws/realtime.ts
+++ b/platform/src/components/aws/realtime.ts
@@ -295,7 +295,7 @@ export class Realtime extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: RealtimeSubscriberArgs,
   ) {
     return all([subscriber, args.filter]).apply(([subscriber, filter]) => {

--- a/platform/src/components/aws/sns-topic.ts
+++ b/platform/src/components/aws/sns-topic.ts
@@ -253,7 +253,7 @@ export class SnsTopic extends Component implements Link.Linkable {
    * ```
    */
   public subscribe(
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: SnsTopicSubscriberArgs = {},
   ) {
     return SnsTopic._subscribeFunction(
@@ -307,7 +307,7 @@ export class SnsTopic extends Component implements Link.Linkable {
    */
   public static subscribe(
     topicArn: Input<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args?: SnsTopicSubscriberArgs,
   ) {
     return output(topicArn).apply((topicArn) =>
@@ -323,7 +323,7 @@ export class SnsTopic extends Component implements Link.Linkable {
   private static _subscribeFunction(
     name: string,
     topicArn: string | Output<string>,
-    subscriber: string | FunctionArgs | Input<FunctionArn>,
+    subscriber: Input<string | FunctionArgs | FunctionArn>,
     args: SnsTopicSubscriberArgs = {},
     opts: $util.ComponentResourceOptions = {},
   ) {


### PR DESCRIPTION
The types for API Gateway routes has changed and broken things.

The underlying types that do the handling all takes Input<T> types so I think these route methods should too. It used to be that way before this commit:
https://github.com/sst/ion/commit/5012d8b3ae600d0f68ce2f045a887618f55b7e19#diff-be8df82cd40fa448a612525e584c3087e242d01aca47acecd39789248a1374b1

EDIT: I saw that many of the route types did not match the underlying types and fixed those. I only use the ones in APIGatewayV2 myself though.

Typescript does not catch these as errors because of the transparency of the Input<T> type. Since Input<T> = T it will pass type check even though the types does not really match and the API outwards seems off.

