### PR TITLE
feat: implement `get` for dynamoDB

### DIFF
--- a/platform/src/components/aws/dynamo.ts
+++ b/platform/src/components/aws/dynamo.ts
@@ -292,7 +292,7 @@ export interface DynamoSubscriberArgs {
 
 interface DynamoRef {
   ref: boolean;
-  table: Input<dynamodb.Table>;
+  table: dynamodb.Table;
 }
 
 /**
@@ -705,12 +705,12 @@ export class Dynamo extends Component implements Link.Linkable {
    *
    * ```ts title=sst.config.ts"
    * const table = $app.stage === "frank"
-   *  ? sst.aws.Dynamo.get("MyTable", "app-dev-table-12345678")
+   *  ? sst.aws.Dynamo.get("MyTable", "app-dev-mytable")
    *  : new sst.aws.Dynamo("MyTable");
    * ```
    *
-   * Here `app-dev-table-12345678` is the auto-generated table name for the table created
-   * in the `dev` stage. You can find this by outputting the table name in the `dev` stage.
+   * Here `app-dev-mytable` is the name of the DynamoDB Table created in the `dev` stage.
+   * You can find this by outputting the table name in the `dev` stage.
    *
    * ```ts title="sst.config.ts"
    * return {
@@ -722,7 +722,7 @@ export class Dynamo extends Component implements Link.Linkable {
     return new Dynamo(name, {
       ref: true,
       table: dynamodb.Table.get(`${name}Table`, tableName),
-    } as unknown as DynamoArgs);
+    } satisfies DynamoRef as unknown as DynamoArgs);
   }
 
   /** @internal */

--- a/platform/src/components/aws/dynamo.ts
+++ b/platform/src/components/aws/dynamo.ts
@@ -290,6 +290,11 @@ export interface DynamoSubscriberArgs {
   };
 }
 
+interface DynamoRef {
+  ref: boolean;
+  table: Input<dynamodb.Table>;
+}
+
 /**
  * The `Dynamo` component lets you add an [Amazon DynamoDB](https://aws.amazon.com/dynamodb/) table to your app.
  *
@@ -404,13 +409,19 @@ export class Dynamo extends Component implements Link.Linkable {
     opts: ComponentResourceOptions = {},
   ) {
     super(__pulumiType, name, args, opts);
+    this.constructorName = name;
+    this.constructorOpts = opts;
+
+    if (args && "ref" in args) {
+      const ref = args as unknown as DynamoRef;
+      this.table = output(ref.table);
+      return;
+    }
 
     const parent = this;
 
     const table = createTable();
 
-    this.constructorName = name;
-    this.constructorOpts = opts;
     this.table = table;
     this.isStreamEnabled = Boolean(args.stream);
 
@@ -674,6 +685,44 @@ export class Dynamo extends Component implements Link.Linkable {
         opts,
       );
     });
+  }
+
+  /**
+   * Reference an existing DynamoDB Table with the given table name. This is useful when you
+   * create a table in one stage and want to share it in another stage. It avoid having to
+   * create a new table in the other stage.
+   *
+   * :::tip
+   * You can use the `static get` method to share a table across stages.
+   * :::
+   *
+   * @param name The name of the component.
+   * @param tableName The name of the DynamoDB Table.
+   *
+   * @example
+   * Imagine you create a table in the `dev` stage. And in your personal stage `frank`,
+   * instead of creating a new table, you want to share the table from `dev`.
+   *
+   * ```ts title=sst.config.ts"
+   * const table = $app.stage === "frank"
+   *  ? sst.aws.Dynamo.get("MyTable", "app-dev-table-12345678")
+   *  : new sst.aws.Dynamo("MyTable");
+   * ```
+   *
+   * Here `app-dev-table-12345678` is the auto-generated table name for the table created
+   * in the `dev` stage. You can find this by outputting the table name in the `dev` stage.
+   *
+   * ```ts title="sst.config.ts"
+   * return {
+   *   table: table.name
+   * };
+   * ```
+   */
+  public static get(name: string, tableName: Input<string>) {
+    return new Dynamo(name, {
+      ref: true,
+      table: dynamodb.Table.get(`${name}Table`, tableName),
+    } as unknown as DynamoArgs);
   }
 
   /** @internal */


### PR DESCRIPTION
closes sst/sst#4040

I tried to match the Bucket's `get` static method as best I could