### PR TITLE
fix: wait for resource creation before deploying api gateway v1

### DIFF
--- a/platform/src/components/aws/apigatewayv1.ts
+++ b/platform/src/components/aws/apigatewayv1.ts
@@ -1270,7 +1270,7 @@ export class ApiGatewayV1 extends Component implements Link.Linkable {
               ),
             ),
           },
-          { parent },
+          { parent, dependsOn: resources },
         ),
       );
     }


### PR DESCRIPTION
Sets `dependsOn` to `resources` when API Gateway V1 deployments are created. Prevents the following exception:
> BadRequestException: The REST API doesn't contain any methods...

We've seen this when deploying stages where the Gateway is configured with a deployment trigger. Can't think of any cases where this could cause problems? 