### PR TITLE
chore: update open-next version in Nextjs component 

### DIFF
--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -593,10 +593,11 @@ export class Nextjs extends Component implements Link.Linkable {
     function normalizeBuildCommand() {
       return all([args?.buildCommand, args?.openNextVersion]).apply(
         ([buildCommand, openNextVersion]) => {
+          if (buildCommand) return buildCommand;
           const version = openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION;
           const packageName = getOpenNextPackage(version);
-
-          return buildCommand ?? `npx --yes ${packageName}@${version} build`;
+          
+          return `npx --yes ${packageName}@${version} build`;
         }
       );
     }

--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -26,8 +26,9 @@ import { Queue } from "./queue.js";
 import { buildApp } from "../base/base-ssr-site.js";
 import { dynamodb, lambda } from "@pulumi/aws";
 import { URL_UNAVAILABLE } from "./linkable.js";
+import { getOpenNextPackage } from "../../util/compare-semver.js";
 
-const DEFAULT_OPEN_NEXT_VERSION = "3.0.8";
+const DEFAULT_OPEN_NEXT_VERSION = "3.1.4";
 const DEFAULT_CACHE_POLICY_ALLOWED_HEADERS = ["x-open-next-cache-key"];
 
 type BaseFunction = {
@@ -591,14 +592,12 @@ export class Nextjs extends Component implements Link.Linkable {
 
     function normalizeBuildCommand() {
       return all([args?.buildCommand, args?.openNextVersion]).apply(
-        ([buildCommand, openNextVersion]) =>
-          buildCommand ??
-          [
-            "npx",
-            "--yes",
-            `open-next@${openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION}`,
-            "build",
-          ].join(" "),
+        ([buildCommand, openNextVersion]) => {
+          const version = openNextVersion ?? DEFAULT_OPEN_NEXT_VERSION;
+          const packageName = getOpenNextPackage(version);
+
+          return buildCommand ?? `npx --yes ${packageName}@${version} build`;
+        }
       );
     }
 
@@ -789,39 +788,39 @@ export class Nextjs extends Component implements Link.Linkable {
               },
               ...(revalidationQueueArn
                 ? [
-                    {
-                      actions: [
-                        "sqs:SendMessage",
-                        "sqs:GetQueueAttributes",
-                        "sqs:GetQueueUrl",
-                      ],
-                      resources: [revalidationQueueArn],
-                    },
-                  ]
+                  {
+                    actions: [
+                      "sqs:SendMessage",
+                      "sqs:GetQueueAttributes",
+                      "sqs:GetQueueUrl",
+                    ],
+                    resources: [revalidationQueueArn],
+                  },
+                ]
                 : []),
               ...(revalidationTableArn
                 ? [
-                    {
-                      actions: [
-                        "dynamodb:BatchGetItem",
-                        "dynamodb:GetRecords",
-                        "dynamodb:GetShardIterator",
-                        "dynamodb:Query",
-                        "dynamodb:GetItem",
-                        "dynamodb:Scan",
-                        "dynamodb:ConditionCheckItem",
-                        "dynamodb:BatchWriteItem",
-                        "dynamodb:PutItem",
-                        "dynamodb:UpdateItem",
-                        "dynamodb:DeleteItem",
-                        "dynamodb:DescribeTable",
-                      ],
-                      resources: [
-                        revalidationTableArn,
-                        `${revalidationTableArn}/*`,
-                      ],
-                    },
-                  ]
+                  {
+                    actions: [
+                      "dynamodb:BatchGetItem",
+                      "dynamodb:GetRecords",
+                      "dynamodb:GetShardIterator",
+                      "dynamodb:Query",
+                      "dynamodb:GetItem",
+                      "dynamodb:Scan",
+                      "dynamodb:ConditionCheckItem",
+                      "dynamodb:BatchWriteItem",
+                      "dynamodb:PutItem",
+                      "dynamodb:UpdateItem",
+                      "dynamodb:DeleteItem",
+                      "dynamodb:DescribeTable",
+                    ],
+                    resources: [
+                      revalidationTableArn,
+                      `${revalidationTableArn}/*`,
+                    ],
+                  },
+                ]
                 : []),
             ],
           };

--- a/platform/src/util/compare-semver.ts
+++ b/platform/src/util/compare-semver.ts
@@ -1,0 +1,19 @@
+export function compareSemver(v1: string, v2: string): number {
+  if (v1 === "latest") return 1;
+  if (/^[^\d]/.test(v1)) {
+    v1 = v1.substring(1);
+  }
+  if (/^[^\d]/.test(v2)) {
+    v2 = v2.substring(1);
+  }
+  const [major1, minor1, patch1] = v1.split(".").map(Number);
+  const [major2, minor2, patch2] = v2.split(".").map(Number);
+
+  if (major1 !== major2) return major1 - major2;
+  if (minor1 !== minor2) return minor1 - minor2;
+  return patch1 - patch2;
+}
+
+export function getOpenNextPackage(openNextVersion: string): string {
+  return compareSemver(openNextVersion, "3.1.13") <= 0 ? "open-next" : "@opennextjs/aws";
+}


### PR DESCRIPTION
This PR bumps the default OpenNext version to be the latest which is `3.1.4`. It also changes the build command to address that OpenNext => `3.1.13` needs to use the new package called: `@opennextjs/aws`. 

If its `3.1.13` or lower it will use the old `open-next` package.