### PR TITLE
feat(platform): support `secrets` for container definitions

### DIFF
--- a/platform/src/components/aws/cluster.ts
+++ b/platform/src/components/aws/cluster.ts
@@ -857,6 +857,30 @@ export interface ClusterServiceArgs {
     retention?: Input<keyof typeof RETENTION>;
   }>;
   /**
+   * Configure secrets to expose to your container.
+   * @example
+   * ```js
+   * {
+   *   secrets: [
+   *     {
+   *       name: "DATABASE_PASSWORD",
+   *       valueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-123abc"
+   *     }
+   *   ]
+   * }
+   * ```
+   */
+  secrets?: Input<{
+    /**
+     * The name of the environment variable to set in the container.
+     */
+    name: string;
+    /**
+     * The secret to expose to the container. The supported values are either the full Amazon Resource Name (ARN) of the AWS Secrets Manager secret or the full ARN of the parameter in the AWS Systems Manager Parameter Store.
+     */
+    valueFrom: string;
+  }[]>;
+  /**
    * Mount Amazon EFS file systems into the container.
    *
    * @example
@@ -1011,12 +1035,25 @@ export interface ClusterServiceArgs {
      * Configure the service's logs in CloudWatch. Same as the top-level [`logging`](#logging).
      */
     logging?: Input<{
-      /**
-       * The duration the logs are kept in CloudWatch. Same as the top-level
-       * [`logging.retention`](#logging-retention).
-       */
-      retention?: Input<keyof typeof RETENTION>;
+    /**
+     * The duration the logs are kept in CloudWatch. Same as the top-level
+     * [`logging.retention`](#logging-retention).
+     */
+    retention?: Input<keyof typeof RETENTION>;
     }>;
+    /**
+     * An object that represents the secret to expose to your container (from AWS Secrets Manager or from AWS Systems Manager Parameter Store).
+     * @example
+     * ```js
+     * [
+     *   {
+     *     "name": "environment_variable_name",
+     *     "valueFrom": "arn:aws:ssm:region:aws_account_id:parameter/parameter_name"
+     *   }
+     * ]
+     * ```
+     */
+    secrets?: ClusterServiceArgs["secrets"];
     /**
      * Mount Amazon EFS file systems into the container. Same as the top-level
      * [`efs`](#efs).

--- a/platform/src/components/aws/service.ts
+++ b/platform/src/components/aws/service.ts
@@ -241,10 +241,10 @@ export class Service extends Component implements Link.Linkable {
     function normalizeContainers() {
       if (
         args.containers &&
-        (args.image || args.logging || args.environment || args.volumes)
+        (args.image || args.logging || args.environment || args.volumes || args.secrets)
       ) {
         throw new VisibleError(
-          `You cannot provide both "containers" and "image", "logging", "environment" or "volumes".`,
+          `You cannot provide both "containers" and "image", "logging", "environment", "volumes" or "secrets".`,
         );
       }
 
@@ -255,6 +255,7 @@ export class Service extends Component implements Link.Linkable {
           image: args.image,
           logging: args.logging,
           environment: args.environment,
+          secrets: args.secrets,
           volumes: args.volumes,
           command: args.command,
           entrypoint: args.entrypoint,
@@ -679,6 +680,10 @@ export class Service extends Component implements Link.Linkable {
                       sourceVolume: volume.efs.accessPoint,
                       containerPath: volume.path,
                     })),
+                    secrets: container.secrets?.map((secret) => ({
+                      name: secret.name,
+                      valueFrom: secret.valueFrom
+                    }))
                   };
 
                   function createImage() {


### PR DESCRIPTION
#### Description:
This PR extends SST.dev's functionality to allow passing secrets to container definitions on Fargate services. Previously, only environment variables were supported. This enhancement enables secure handling of sensitive information like credentials coming form Secrets Manager or Parameter Store.

```
"secrets": [
    {
        "name": "environment_variable_name",
        "valueFrom": "arn:aws:ssm:region:aws_account_id:parameter/parameter_name"
    }
]
```

OP: https://discord.com/channels/983865673656705025/983865673656705028/1296993077982003331

#### Changes:
- Added `secrets` property to container definition schema (as per [Container Definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions))

#### ~Missing:~
~- Update documentation to reflect new `secrets` arg in the [Service section](https://sst.dev/docs/component/aws/service/#serviceargs)~

