### PR TITLE
Provide the ability to specify a response headers policy

### DIFF
--- a/platform/src/components/aws/analog.ts
+++ b/platform/src/components/aws/analog.ts
@@ -269,6 +269,17 @@ export interface AnalogArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the Analog app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/astro.ts
+++ b/platform/src/components/aws/astro.ts
@@ -270,6 +270,17 @@ export interface AstroArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the Astro site to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 const BUILD_META_FILE_NAME: BuildMetaFileName = "sst.buildMeta.json";

--- a/platform/src/components/aws/nextjs.ts
+++ b/platform/src/components/aws/nextjs.ts
@@ -407,6 +407,17 @@ export interface NextjsArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the Next.js app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/nuxt.ts
+++ b/platform/src/components/aws/nuxt.ts
@@ -270,6 +270,17 @@ export interface NuxtArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the Nuxt app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/react.ts
+++ b/platform/src/components/aws/react.ts
@@ -274,6 +274,17 @@ export interface ReactArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the React app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/remix.ts
+++ b/platform/src/components/aws/remix.ts
@@ -276,6 +276,17 @@ export interface RemixArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the Remix app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/solid-start.ts
+++ b/platform/src/components/aws/solid-start.ts
@@ -266,6 +266,17 @@ export interface SolidStartArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the SolidStart app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/ssr-site.ts
+++ b/platform/src/components/aws/ssr-site.ts
@@ -57,6 +57,7 @@ export interface SsrSiteArgs extends BaseSsrSiteArgs {
   domain?: CdnArgs["domain"];
   permissions?: FunctionArgs["permissions"];
   cachePolicy?: Input<string>;
+  responseHeadersPolicy?: Input<string>;
   invalidation?: Input<
     | false
     | {
@@ -792,6 +793,7 @@ export function createServersAndDistribution(
           compress: true,
           // CloudFront's managed CachingOptimized policy
           cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+          responseHeadersPolicyId: args.responseHeadersPolicy,
           functionAssociations: behavior.cfFunction
             ? [
                 {
@@ -821,6 +823,7 @@ export function createServersAndDistribution(
           cachedMethods: ["GET", "HEAD"],
           compress: true,
           cachePolicyId: args.cachePolicy ?? useServerBehaviorCachePolicy().id,
+          responseHeadersPolicyId: args.responseHeadersPolicy,
           // CloudFront's Managed-AllViewerExceptHostHeader policy
           originRequestPolicyId: "b689b0a8-53d0-40ab-baf2-68738e2966ac",
           functionAssociations: behavior.cfFunction

--- a/platform/src/components/aws/svelte-kit.ts
+++ b/platform/src/components/aws/svelte-kit.ts
@@ -274,6 +274,17 @@ export interface SvelteKitArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the SvelteKit app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**

--- a/platform/src/components/aws/tanstack-start.ts
+++ b/platform/src/components/aws/tanstack-start.ts
@@ -266,6 +266,17 @@ export interface TanstackStartArgs extends SsrSiteArgs {
    * ```
    */
   cachePolicy?: SsrSiteArgs["cachePolicy"];
+  /**
+   * Configure the TanstackStart app to use an existing CloudFront response headers policy.
+   *
+   * @example
+   * ```js
+   * {
+   *   responseHeadersPolicy: "eaab4381-ed33-4a86-88ca-d9558dc6cd63"
+   * }
+   * ```
+   */
+  responseHeadersPolicy?: SsrSiteArgs["responseHeadersPolicy"];
 }
 
 /**


### PR DESCRIPTION
We are having to do this currently, which is pretty nasty:
```
new sst.aws.Nextjs('app', {
  ...args,
  transform: {
    cdn: {
      transform: {
        distribution: (args) => {
          args.defaultCacheBehavior = {
            ...args.defaultCacheBehavior,
            responseHeadersPolicyId: responseHeadersPolicy,
          }
          args.orderedCacheBehaviors = args.orderedCacheBehaviors
            ? $output(args.orderedCacheBehaviors).apply((behaviours) =>
                behaviours.map((behaviour) => ({ ...behaviour, responseHeadersPolicyId: responseHeadersPolicy }))
              )
            : undefined
        },
      },
    },
  },
})
```
After these changes:
```
new sst.aws.Nextjs('app', {
  ...args,
  responseHeadersPolicy
})
```
There was a `responseHeadersPolicy` prop in SST v2, and we were using it, so it's likely that others are too.